### PR TITLE
fix for star macro with no `from` arg

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,20 +1,19 @@
-{% macro star(from, except=[]) -%}
+{% macro star(from=none, except=[]) -%}
+    {%- if from is not none -%}
+        {%- set table_parts = (from | string | replace('"', '')).split('.') %}
+        {%- set include_cols = [] %}
+        {%- set cols = adapter.get_columns_in_table(*table_parts) %}
+        {%- for col in cols -%}
+            {%- if col.column not in except -%}
+                {% set _ = include_cols.append(col.column) %}
+            {%- endif %}
+        {%- endfor %}
 
-    {%- set table_parts = from.split('.') %}
-    {%- set include_cols = [] %}
-    {%- set cols = adapter.get_columns_in_table(*table_parts) %}
-    {%- for col in cols -%}
-
-        {%- if col.column not in except -%}
-            {% set _ = include_cols.append(col.column) %}
-
-        {%- endif %}
-    {%- endfor %}
-
-    {%- for col in include_cols %}
-
-        "{{ col }}" {% if not loop.last %},
-        {% endif %}
-
-    {%- endfor -%}
+        {%- for col in include_cols %}
+            "{{ col }}" {% if not loop.last %},
+            {% endif %}
+        {%- endfor -%}
+    {%- else -%}
+        *
+    {%- endif -%}
 {%- endmacro %}


### PR DESCRIPTION
this can happen either in the dbt parsing step, or intentionally. If no `from` is provided, then `*` is used.