### PR TITLE
compatibility with 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 ----
 
 # dbt-utils
+
+Current version: 0.1.0
+
 This package contains macros that can be (re)used across dbt projects.
 
 ## Macros

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_utils'
-version: '1.0'
+version: '0.1.0'
 
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -4,8 +4,8 @@
 
 -- setup
 
-{% set schema = model.split('.')[0] | replace('"', '') %}
-{% set model_a_name = model.split('.')[1] | replace('"', '') %}
+{% set schema = model.schema %}
+{% set model_a_name = model.name %}
 
 {% set dest_columns = adapter.get_columns_in_table(schema, model_a_name) %}
 {% set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') %}


### PR DESCRIPTION
Changes:

- `ref()` now returns a `dbt.utils.Relation`, which has `name` and `schema` as properties