### PR TITLE
prefix adapter macro with package name (for 091)

### DIFF
--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -1,5 +1,5 @@
 {% macro current_timestamp() %}
-  {{ adapter_macro('current_timestamp') }}
+  {{ adapter_macro('dbt_utils.current_timestamp') }}
 {% endmacro %}
 
 {% macro default__current_timestamp() %}
@@ -7,5 +7,9 @@
 {% endmacro %}
 
 {% macro redshift__current_timestamp() %}
+    current_timestamp::timestamp
+{% endmacro %}
+
+{% macro postgres__current_timestamp() %}
     current_timestamp::timestamp
 {% endmacro %}

--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -1,5 +1,5 @@
 {% macro dateadd(datepart, interval, from_date_or_timestamp) %}
-  {{ adapter_macro('dateadd', datepart, interval, from_date_or_timestamp) }}
+  {{ adapter_macro('dbt_utils.dateadd', datepart, interval, from_date_or_timestamp) }}
 {% endmacro %}
 
 

--- a/macros/cross_db_utils/split_part.sql
+++ b/macros/cross_db_utils/split_part.sql
@@ -1,5 +1,5 @@
 {% macro split_part(string_text, delimiter_text, part_number) %}
-  {{ adapter_macro('split_part', string_text, delimiter_text, part_number) }}
+  {{ adapter_macro('dbt_utils.split_part', string_text, delimiter_text, part_number) }}
 {% endmacro %}
 
 

--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -22,7 +22,7 @@ all_periods as (
 
     select (
         {{
-            dateadd(
+            dbt_utils.dateadd(
                 datepart,
                 "row_number() over () - 1",
                 start_date


### PR DESCRIPTION
This makes `date_spine`, in addition to the other macros which use `adapter_macro` work with dbt 0.9.1