### PR TITLE
Add cardinality equality schema test

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ model_name:
 ```
 
 #### at_least_one ([source](macros/schema_tests/at_least_one.sql))
-This schema test asserts if column has at least one value. 
+This schema test asserts if column has at least one value.
 
 Usage:
 ```
@@ -93,6 +93,17 @@ model_name:
     not_constant:
       - column_name
 
+```
+
+#### cardinality_equality ([source](macros/schema_tests/cardinality_equality.sql))
+This schema test asserts if values in a given column have exactly the same cardinality as values from a different column in a different model.
+
+Usage:
+```
+model_name:
+  constraints:
+    cardinality_equality:
+    - {from: column_name, to: ref('other_model_name'), field: other_column_name}
 ```
 
 ---

--- a/macros/schema_tests/cardinality.sql
+++ b/macros/schema_tests/cardinality.sql
@@ -1,6 +1,0 @@
-{% macro test_cardinality(model, arg) %}
-
-select {{ arg.field }}
-from {{ model }}
-
-{% endmacro %}

--- a/macros/schema_tests/cardinality.sql
+++ b/macros/schema_tests/cardinality.sql
@@ -1,0 +1,6 @@
+{% macro test_cardinality(model, arg) %}
+
+select {{ arg.field }}
+from {{ model }}
+
+{% endmacro %}

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -2,18 +2,18 @@
 
 with table_a as (
 select
-  count(1) as num_rows,
-  {{ from }}
+  {{ from }},
+  count(1) as num_rows
 from {{ model }}
-group by 2
+group by 1
 ),
 
 table_b as (
 select
-  count(1) as num_rows,
-  {{ field }}
+  { field }},
+  count(1) as num_rows
 from {{ to }}
-group by 2
+group by 1
 )
 
 select count(1)

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -14,15 +14,31 @@ select
   count(1) as num_rows
 from {{ to }}
 group by 1
+),
+
+except_a as (
+  select *
+  from table_a
+  except
+  select *
+  from table_b
+),
+
+except_b as (
+  select *
+  from table_b
+  except
+  select *
+  from table_a
 )
 
 select count(1)
 from (
-select *
-from table_a
-except
-select *
-from table_b
+  select *
+  from except_a
+  union all
+  select *
+  from except_b
 )
 
 {% endmacro %}

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -3,15 +3,15 @@
 with table_a as (
 select
   {{ from }},
-  count(1) as num_rows
+  count(*) as num_rows
 from {{ model }}
 group by 1
 ),
 
 table_b as (
 select
-  { field }},
-  count(1) as num_rows
+  {{ field }},
+  count(*) as num_rows
 from {{ to }}
 group by 1
 ),
@@ -30,15 +30,17 @@ except_b as (
   except
   select *
   from table_a
-)
+),
 
-select count(1)
-from (
+unioned as (
   select *
   from except_a
   union all
   select *
   from except_b
 )
+
+select count(*)
+from unioned
 
 {% endmacro %}

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -1,0 +1,28 @@
+{% macro test_cardinality_equality(model, from, to, field) %}
+
+with table_a as (
+select
+  count(1) as num_rows,
+  {{ from }}
+from {{ model }}
+group by 2
+),
+
+table_b as (
+select
+  count(1) as num_rows,
+  {{ field }}
+from {{ to }}
+group by 2
+)
+
+select count(1)
+from (
+select *
+from table_a
+except
+select *
+from table_b
+)
+
+{% endmacro %}


### PR DESCRIPTION
This custom schema test macro checks to see if the cardinality of one field in a model exactly matches the cardinality of a chosen field in a different model.