### PR TITLE
added new generate_series macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Usage:
 ```
 {{ dbt_utils.union_tables(tables=[ref('table_1'), ref('table_2')], column_override={"some_field": "varchar(100)"}) }}
 ```
+
+#### generate_series ([source](macros/sql/generate_series.sql))
+This macro implements a cross-database mechanism to generate an arbitrarily long list of numbers. Specify the maximum number you'd like in your list and it will create a 1-indexed SQL result set.
+
+Usage:
+```
+{{ dbt_utils.generate_series(upper_bound=1000) }}
+```
 ---
 ### Web
 #### get_url_parameter ([source](macros/web/get_url_parameter.sql))

--- a/macros/sql/generate_series.sql
+++ b/macros/sql/generate_series.sql
@@ -1,0 +1,53 @@
+{% macro get_powers_of_two(upper_bound) %}
+
+    {% if upper_bound <= 0 %}
+    {{ exceptions.raise_compiler_error("upper bound must be positive") }}
+    {% endif %}
+
+    {% for _ in range(1, upper_bound + 2) %}
+       {% if upper_bound <= 2 ** loop.index %}{{ return(loop.index) }}{% endif %}
+    {% endfor %}
+
+{% endmacro %}
+
+
+{% macro generate_series(upper_bound) %}
+
+    {% set n = dbt_utils.get_powers_of_two(upper_bound) %}
+
+    with
+
+    {% for i in range(n) %}
+
+    p{{i}} as (
+        select 0 as generated_number union all select 1
+    ) {% if not loop.last %},{% endif %}
+
+    {% endfor %}
+
+    , unioned as (
+
+    select
+
+    {% for i in range(n) %}
+    p{{i}}.generated_number * pow(2, {{i}})
+    {% if not loop.last %} + {% endif %}
+    {% endfor %}
+    + 1
+    as generated_number
+
+    from
+
+    {% for i in range(n) %}
+    p{{i}}
+    {% if not loop.last %} cross join {% endif %}
+    {% endfor %}
+
+    )
+
+    select *
+    from unioned
+    where generated_number <= {{upper_bound}}
+    order by generated_number
+
+{% endmacro %}


### PR DESCRIPTION
addresses https://github.com/fishtown-analytics/dbt-utils/issues/33

have tested this on redshift, bigquery, postgres, and snowflake. the sql is pretty generic so fortunately no cross-db rewrites to worry about.