### PR TITLE
Use `return` in get_column_values

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This macro returns the unique values for a column in a given table.
 Usage:
 ```
 -- Returns a list of the top 50 states in the `users` table
-{% set states = fromjson(dbt_utils.get_column_values(table=ref('users'), column='state', max_records=50)) %}
+{% set states = dbt_utils.get_column_values(table=ref('users'), column='state', max_records=50) %}
 
 {% for state in states %}
     ...

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -6,6 +6,9 @@ Arguments:
     table: A model `ref`, or a schema.table string for the table to query (Required)
     column: The column to query for unique values
     max_records: If provided, the maximum number of unique records to return (default: none)
+
+Returns:
+    A list of distinct values for the specified columns
 #}
 
 {% macro get_column_values(table, column, max_records=none) -%}
@@ -29,9 +32,9 @@ Arguments:
 
     {%- if value_list and value_list['data'] -%}
         {%- set values = value_list['data'] | map(attribute=0) | list %}
-        {{ tojson(values) }}
+        {{ return(values) }}
     {%- else -%}
-        []
+        {{ return([]) }}
     {%- endif -%}
 
 {%- endmacro %}


### PR DESCRIPTION
Before dbt 0.9.0 dropped, there was no way to `return` non-string values from macros. Since the `return` function works like a charm now, we should definitely be using it here.