### PR TITLE
Have get url paramater macro return null when blank

### DIFF
--- a/macros/web/get_url_parameter.sql
+++ b/macros/web/get_url_parameter.sql
@@ -1,9 +1,9 @@
-{% macro get_url_parameter(field, url_parameter) %}
+{% macro get_url_parameter(field, url_parameter) -%}
 
-{% set formatted_url_parameter = "'" + url_parameter + "='" %}
+{%- set formatted_url_parameter = "'" + url_parameter + "='" -%}
 
-{{
-    dbt_utils.split_part(dbt_utils.split_part(field, formatted_url_parameter, 2), "'&'", 1)
-}}
+{%- set split = dbt_utils.split_part(dbt_utils.split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
 
-{% endmacro %}
+nullif({{ split }},'')
+
+{%- endmacro %}


### PR DESCRIPTION
This alters the `get_url_paramater` macro to return NULL instead of an empty string when no relevant parameters are found in the URL being parsed.