### PR TITLE
fix for orderby on snowflake

### DIFF
--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -47,7 +47,7 @@ all_periods as (
         {{
             dbt_utils.dateadd(
                 datepart,
-                "row_number() over () - 1",
+                "row_number() over (order by 1) - 1",
                 start_date
             )
         }}


### PR DESCRIPTION
Snowflake requires that the `row_number()` window function uses an `order by` clause

Test with:
- [x] Redshift
- [x] BQ