### PR TITLE
fixed issue 49

### DIFF
--- a/macros/cross_db_utils/datediff.sql
+++ b/macros/cross_db_utils/datediff.sql
@@ -17,8 +17,8 @@
 {% macro bigquery__datediff(first_date, second_date, datepart) %}
 
     date_diff(
-        {{first_date}},
         {{second_date}},
+        {{first_date}},
         {{datepart}}
         )
 


### PR DESCRIPTION
https://github.com/fishtown-analytics/dbt-utils/issues/49

Just read the docs and confirmed that the argument ordering for redshift and bigquery is opposite for the two datetime fields. Very annoying, but an easy fix.