### PR TITLE
Feature/last day

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ Usage:
 ```
 {{ dbt_utils.split_part(string_text='1,2,3', delimiter_text=',', part_number=1) }}
 ```
+
+#### date_trunc ([source](macros/cross_db_utils/date_trunc.sql))
+Truncates a date or timestamp to the specified datepart. Note: The `datepart` argument is database-specific.
+
+Usage:
+```
+{{ dbt_utils.date_trunc(datepart, date) }}
+```
+
+#### last_day ([source](macros/cross_db_utils/last_day.sql))
+Gets the last day for a given date and datepart. Notes:
+
+- The `datepart` argument is database-specific.
+- This macro currently only supports dateparts of `month` and `quarter`.
+
+Usage:
+```
+{{ dbt_utils.last_day(date, datepart) }}
+```
 ---
 ### Date/Time
 #### date_spine ([source](macros/datetime/date_spine.sql))

--- a/macros/cross_db_utils/date_trunc.sql
+++ b/macros/cross_db_utils/date_trunc.sql
@@ -1,0 +1,11 @@
+{% macro date_trunc(datepart, date) %}
+  {{ adapter_macro('dbt_utils.date_trunc', datepart, date) }}
+{% endmacro %}
+
+{% macro default__date_trunc(datepart, date) %}
+    date_trunc('{{datepart}}', {{date}})
+{% endmacro %}
+
+{% macro bigquery__date_trunc(datepart, date) %}
+    date_trunc({{date}}, {{datepart}})
+{% endmacro %}

--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -18,8 +18,7 @@
 
     date_add(
         {{ from_date_or_timestamp }},
-        {{ interval }},
-        "{{ datepart }}"
+        INTERVAL {{ interval }} {{ datepart }}
         )
 
 {% endmacro %}

--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -18,7 +18,7 @@
 
     date_add(
         {{ from_date_or_timestamp }},
-        INTERVAL {{ interval }} {{ datepart }}
+        interval {{ interval }} {{ datepart }}
         )
 
 {% endmacro %}

--- a/macros/cross_db_utils/last_day.sql
+++ b/macros/cross_db_utils/last_day.sql
@@ -8,30 +8,27 @@ testing is required to validate that it will work on other dateparts.
 {% endmacro %}
 
 
-{% macro default__last_day(date, datepart) -%}
+{%- macro default_last_day(date, datepart) -%}
     cast(
         {{dbt_utils.dateadd('day', '-1',
         dbt_utils.dateadd(datepart, '1', dbt_utils.date_trunc(datepart, date))
         )}}
         as date)
+{%- endmacro -%}
+
+
+{% macro default__last_day(date, datepart) -%}
+    {{dbt_utils.default_last_day(date, datepart)}}
 {%- endmacro %}
 
 
 {% macro postgres__last_day(date, datepart) -%}
 
     {%- if datepart == 'quarter' -%}
-
     {{ exceptions.raise_compiler_error(
         "dbt_utils.last_day is not supported for datepart 'quarter' on this adapter") }}
-
     {%- else -%}
-
-    cast(
-        {{dbt_utils.dateadd('day', '-1',
-        dbt_utils.dateadd(datepart, '1', dbt_utils.date_trunc(datepart, date))
-        )}}
-        as date)
-
+    {{dbt_utils.default_last_day(date, datepart)}}
     {%- endif -%}
 
 {%- endmacro %}

--- a/macros/cross_db_utils/last_day.sql
+++ b/macros/cross_db_utils/last_day.sql
@@ -1,0 +1,32 @@
+{% macro last_day(date, datepart) %}
+  {{ adapter_macro('dbt_utils.last_day', date, datepart) }}
+{% endmacro %}
+
+
+{% macro default__last_day(date, datepart) -%}
+    cast(
+        {{dbt_utils.dateadd('day', '-1',
+        dbt_utils.dateadd(datepart, '1', dbt_utils.date_trunc(datepart, date))
+        )}}
+        as date)
+{%- endmacro %}
+
+
+{% macro postgres__last_day(date, datepart) -%}
+
+    {%- if datepart == 'quarter' -%}
+
+    {{ exceptions.raise_compiler_error(
+        "dbt_utils.last_day is not supported for datepart 'quarter' on this adapter") }}
+
+    {%- else -%}
+
+    cast(
+        {{dbt_utils.dateadd('day', '-1',
+        dbt_utils.dateadd(datepart, '1', dbt_utils.date_trunc(datepart, date))
+        )}}
+        as date)
+
+    {%- endif -%}
+
+{%- endmacro %}

--- a/macros/cross_db_utils/last_day.sql
+++ b/macros/cross_db_utils/last_day.sql
@@ -1,3 +1,8 @@
+/*
+This function has been tested with dateparts of month and quarters. Further
+testing is required to validate that it will work on other dateparts.
+*/
+
 {% macro last_day(date, datepart) %}
   {{ adapter_macro('dbt_utils.last_day', date, datepart) }}
 {% endmacro %}


### PR DESCRIPTION
@drewbanin couple of things:

1. it turns out that `last_day` isn't widely supported across adapters (postgres and bigquery don't have it at all, and it's inconsistently implemented across redshift and snowflake).

2. I only particularly care about this for months and quarters, and so have only tested it for those. my guess is that there will be inconsistencies in how it works across adapters for weeks and so i just didn't want to get into that because (at least for my use case) this is not valuable. I left a comment so that this is documented in the function.