### PR TITLE
star macro readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,13 @@ Usage:
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a `select` statement for each field that exists in the `from` relation. Fields listed in the `except` argument will be excluded from this list.
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro.
 
 Usage:
 ```
+select
 {{ dbt_utils.star(from=ref('my_model'), except=["exclude_field_1", "exclude_field_2"]) }}
+from {{ref('my_model')}}
 ```
 
 #### union_tables ([source](macros/sql/union.sql))


### PR DESCRIPTION
## Motivation

Updated description + usage for star macro to clarify that one needs to write
```select {{dbt_utils.star(from=table,except=[]) from table```
The star macro only replaces the star, not the entire select statement. Previous wording implied that the macro would generate the entire table expression, cf. `dbt_utils.union_tables`.

## Approach

An alternative approach would be to change the underlying code to actually generate an entire select statement, including the words `select` and `from {{from}}` in the compiled output, but I think there are compelling use cases where we want a star macro coupled with some basic calculation / casting / field population in the same CTE, especially if we're using `dbt_utils.star` to exclude a field that requires slight modification.