### PR TITLE
pivot example bug

### DIFF
--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -14,8 +14,8 @@ Example:
 
     select
       size,
-      {{ dbt_utils.pivot('size', dbt_utils.get_column_values('public.test',
-                                                             'color')) }}
+      {{ dbt_utils.pivot('color', dbt_utils.get_column_values('public.test',
+                                                              'color')) }}
     from public.test
     group by size
 


### PR DESCRIPTION
The example code doesn't match the example output, because it's looking for colours in the size column. This update fixes it as per the example.