### PR TITLE
fix snowflake bugs with 0.10.1 functionality

### DIFF
--- a/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
+++ b/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
@@ -1,12 +1,3 @@
 
-{% if target.type == 'snowflake' %}
-
-    {% set tables = dbt_utils.get_tables_by_prefix((target.schema | upper), 'data_events_') %}
-    {{ dbt_utils.union_tables(tables) }}
-
-{% else %}
-
-    {% set tables = dbt_utils.get_tables_by_prefix(target.schema, 'data_events_') %}
-    {{ dbt_utils.union_tables(tables) }}
-
-{% endif %}
+{% set tables = dbt_utils.get_tables_by_prefix(target.schema, 'data_events_') %}
+{{ dbt_utils.union_tables(tables) }}

--- a/macros/sql/nullcheck_table.sql
+++ b/macros/sql/nullcheck_table.sql
@@ -1,8 +1,9 @@
 {% macro nullcheck_table(schema, table) %}
 
+  {% set source = api.Relation.create(schema=schema, identifier=table) %}
   {% set cols = adapter.get_columns_in_table(schema, table) %}
 
   select {{ dbt_utils.nullcheck(cols) }}
-  from {{schema}}.{{table}}
+  from {{ source }}
   
 {% endmacro %}


### PR DESCRIPTION
In the pre-0.10.1 world, dbt's quoting of relations was inconsistent, leading to bugs in the below macros when run against Snowflake. This PR uses Relation objects to fix those bugs.


This build is failing because 0.10.1 is unreleased. We should merge this code only after the release is published.