### PR TITLE
Feature/current timestamp in utc

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,5 +5,3 @@ target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
-
-profile: snowflake-testing

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,3 +5,5 @@ target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
+
+profile: snowflake-testing

--- a/integration_tests/models/cross_db_utils/test_current_timestamp_in_utc.sql
+++ b/integration_tests/models/cross_db_utils/test_current_timestamp_in_utc.sql
@@ -1,0 +1,5 @@
+
+-- how can we test this better?
+select
+    {{ dbt_utils.current_timestamp_in_utc() }} as actual,
+    {{ dbt_utils.current_timestamp_in_utc() }} as expected

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -3,13 +3,41 @@
 {% endmacro %}
 
 {% macro default__current_timestamp() %}
-    current_timestamp()
+    current_timestamp
 {% endmacro %}
 
 {% macro redshift__current_timestamp() %}
-    current_timestamp::timestamp
+    current_timestamp::{{dbt_utils.type_timestamp()}}
 {% endmacro %}
 
 {% macro postgres__current_timestamp() %}
-    current_timestamp::timestamp
+    current_timestamp::{{dbt_utils.type_timestamp()}}
 {% endmacro %}
+
+
+
+
+
+
+{% macro current_timestamp_in_utc() %}
+  {{ adapter_macro('dbt_utils.current_timestamp_in_utc') }}
+{% endmacro %}
+
+{% macro default__current_timestamp_in_utc() %}
+    {{dbt_utils.current_timestamp()}}
+{% endmacro %}
+
+{% macro snowflake__current_timestamp_in_utc() %}
+    convert_timezone('UTC', {{dbt_utils.current_timestamp()}})::{{dbt_utils.type_timestamp()}}
+{% endmacro %}
+
+{% macro postgres__current_timestamp_in_utc() %}
+    (current_timestamp at time zone 'utc')::{{dbt_utils.type_timestamp()}}
+{% endmacro %}
+
+
+
+
+
+
+

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -3,15 +3,11 @@
 {% endmacro %}
 
 {% macro default__current_timestamp() %}
+    current_timestamp::{{dbt_utils.type_timestamp()}}
+{% endmacro %}
+
+{% macro bigquery__current_timestamp() %}
     current_timestamp
-{% endmacro %}
-
-{% macro redshift__current_timestamp() %}
-    current_timestamp::{{dbt_utils.type_timestamp()}}
-{% endmacro %}
-
-{% macro postgres__current_timestamp() %}
-    current_timestamp::{{dbt_utils.type_timestamp()}}
 {% endmacro %}
 
 

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -16,9 +16,6 @@
 
 
 
-
-
-
 {% macro current_timestamp_in_utc() %}
   {{ adapter_macro('dbt_utils.current_timestamp_in_utc') }}
 {% endmacro %}
@@ -34,10 +31,3 @@
 {% macro postgres__current_timestamp_in_utc() %}
     (current_timestamp at time zone 'utc')::{{dbt_utils.type_timestamp()}}
 {% endmacro %}
-
-
-
-
-
-
-


### PR DESCRIPTION
@drewbanin fairly self-explanatory. I actually hadn't realized that it was so difficult to get a timestamp-no-tz UTC time in each database!! spent a while with this one and tested on all 4 adapters.

I also made changes to the way that `current_timestamp()` works because there have been syntax updates in snowflake and bigquery that allow access to that function in ANSI-standard format (no parens).