### PR TITLE
don't query the database during parsing

### DIFF
--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -1,6 +1,10 @@
 {% macro test_equality(model, arg) %}
 
 
+{#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+{%- if not execute -%}
+    {{ return('') }}
+{% endif %}
 
 -- setup
 

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,5 +1,10 @@
 {% macro star(from, except=[]) -%}
 
+    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+    {%- if not execute -%}
+        {{ return('') }}
+    {% endif %}
+
     {%- if from.name -%}
         {%- set schema_name, table_name = from.schema, from.name -%}
     {%- else -%}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,5 +1,10 @@
 {% macro union_tables(tables, column_override=none, exclude=none) -%}
 
+    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
+    {%- if not execute -%}
+        {{ return('') }}
+    {% endif %}
+
     {%- set exclude = exclude if exclude is not none else [] %}
     {%- set column_override = column_override if column_override is not none else {} %}
 


### PR DESCRIPTION
These changes short-circuit macro execution during the parsing of macros which do not modify the graph. 

dbt is smart enough skip running `statement` blocks during parsing, but it _does_ execute adapter functions like `get_columns_in_table`. As a result, there could be a very appreciable delay between typing `dbt run` and seeing the first lines of output from dbt.

For one project we experimented with, this brought the time-to-stdout down from 25 mins to 30 seconds o_0.

Thanks to @HarlanH for help with testing these changes.


