### PR TITLE
fix for old versions of jinja

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Usage:
     period = "day",
     timestamp_field = "created_at",
     start_date = "2018-01-01",
-    stop_date = "2018-06-01"
+    stop_date = "2018-06-01")
 }}
 
 with events as (

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -48,7 +48,7 @@
   {%- set stop_date = config.get('stop_date') or '' -%}}
   {%- set period = config.get('period') or 'week' -%}
 
-  {%- if not '__PERIOD_FILTER__' is in sql -%}
+  {%- if sql.find('__PERIOD_FILTER__') == -1 -%}
     {%- set error_message -%}
       Model '{{ model.unique_id }}' does not include the required string '__PERIOD_FILTER__' in its sql
     {%- endset -%}


### PR DESCRIPTION
The `in` filter was added to jinja in [v2.10.0](https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-210), but dbt currently has a requirement on jina >= 2.8. Some folks might not have installed dbt for a while, and jinja can fail hard with this error when the `in` filter is used:

```
Compilation Error in macro unknown (materializations/insert_by_period_materialization.sql)
  no test named 'in'
    line 51
      {%- if not '__PERIOD_FILTER__' is in sql -%}
```

This PR uses the built-in `.find` method on Python strings to avoid using partially supported jinja functionality.