### PR TITLE
Add "unpivot" macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Arguments:
     - else_value: Value to use if comparison fails, default is 0
 
 #### unpivot ([source](macros/sql/unpivot.sql))
-This macro "un-pivots" values from columns to rows.
+This macro "un-pivots" a table from wide format to long format. Functionality is similar to pandas [melt](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.melt.html) function.
 
 Usage:
 ```

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Arguments:
     - else_value: Value to use if comparison fails, default is 0
 
 #### unpivot ([source](macros/sql/unpivot.sql))
-This macro pivots values from columns to rows.
+This macro "un-pivots" values from columns to rows.
 
 Usage:
 ```
@@ -274,7 +274,7 @@ Example:
     | 2017-01-01 | S    | red   | complete   |
     | 2017-03-01 | S    | red   | processing |
 
-    {{ dbt_utils.unpivot(ref('orders'), cast_to='varchar', exclude=['status']) }}
+    {{ dbt_utils.unpivot(ref('orders'), cast_to='varchar', exclude=['date','status']) }}
 
     Output:
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,40 @@ Arguments:
     - then_value: Value to use if comparison succeeds, default is 1
     - else_value: Value to use if comparison fails, default is 0
 
+#### unpivot ([source](macros/sql/unpivot.sql))
+This macro pivots values from columns to rows.
+
+Usage:
+```
+{{ dbt_utils.unpivot(table=ref('table_name'), cast_to='datatype', exclude=[<list of columns to exclude from unpivot>]) }}
+```
+
+Example:
+
+    Input: orders
+
+    | date       | size | color | status     |
+    |------------|------|-------|------------|
+    | 2017-01-01 | S    | red   | complete   |
+    | 2017-03-01 | S    | red   | processing |
+
+    {{ dbt_utils.unpivot(ref('orders'), cast_to='varchar', exclude=['status']) }}
+
+    Output:
+
+    | date       | status     | field_name | value |
+    |------------|------------|------------|-------|
+    | 2017-01-01 | complete   | size       | S     |
+    | 2017-01-01 | complete   | color      | red   |
+    | 2017-03-01 | processing | size       | S     |
+    | 2017-03-01 | processing | color      | red   |
+
+Arguments:
+
+    - table: Table name, required
+    - cast_to: The data type to cast the unpivoted values to, default is varchar
+    - exclude: A list of columns to exclude from the unpivot.
+
 ---
 ### Web
 #### get_url_parameter ([source](macros/web/get_url_parameter.sql))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'dbt_utils'
+name: 'dwall_dbt_utils'
 version: '0.1.0'
 
 target-path: "target"

--- a/integration_tests/data/sql/data_unpivot.csv
+++ b/integration_tests/data/sql/data_unpivot.csv
@@ -1,0 +1,4 @@
+customer_id,created_at,status,segment
+123,2017-01-01,active,tier 1
+234,2017-02-01,active,tier 3
+567,2017-03-01,churned,tier 2

--- a/integration_tests/data/sql/data_unpivot_expected.csv
+++ b/integration_tests/data/sql/data_unpivot_expected.csv
@@ -1,0 +1,7 @@
+customer_id,created_at,field_name,value
+123,2017-01-01,status,active
+123,2017-01-01,segment,tier 1
+234,2017-02-01,status,active
+234,2017-02-01,segment,tier 3
+567,2017-03-01,status,churned
+567,2017-03-01,segment,tier 2

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -41,6 +41,11 @@ test_pivot:
         dbt_utils.equality:
             - ref('data_pivot_expected')
 
+test_unpivot:
+    constraints:
+        dbt_utils.equality:
+            - ref('data_unpivot_expected')
+
 
 test_star:
     constraints:

--- a/integration_tests/models/sql/test_unpivot.sql
+++ b/integration_tests/models/sql/test_unpivot.sql
@@ -1,0 +1,1 @@
+{{ dbt_utils.unpivot(table=ref('data_unpivot'), cast_to='varchar', exclude=['customer_id','created_at']) }}

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -33,7 +33,7 @@ Arguments:
     {{ exclude_col }},
     {%- endfor %}
     cast('{{ col.column }}' as varchar) as field_name,
-    {{ dbt_utils.safe_cast(field={{ col.column }}, type={{ cast_to }}) }} as value
+    {{ dbt_utils.safe_cast(field=col.column, type=cast_to) }} as value
   from {{ table }}
   {% if not loop.last -%}
   union all

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -1,0 +1,43 @@
+{#
+Pivot values from columns to rows.
+
+Example Usage: {{ dbt_utils.unpivot(table=ref('users'), cast_to='integer', exclude=['id','created_at']) }}
+
+Arguments:
+    table: Table name, required.
+    cast_to: The datatype to cast all unpivoted columns to. Default is varchar.
+    exclude: A list of columns to exclude from the unpivot operation. Default is none.
+#}
+
+{% macro unpivot(table, cast_to='varchar', exclude=none) -%}
+
+  {%- set exclude = exclude if exclude is not none else [] %}
+
+  {%- set table_columns = {} %}
+
+  {%- set _ = table_columns.update({table: []}) %}
+
+  {%- if table.name -%}
+    {%- set schema, table_name = table.schema, table.name -%}
+  {%- else -%}
+    {%- set schema, table_name = (table | string).split(".") -%}
+  {%- endif -%}
+
+  {%- set cols = adapter.get_columns_in_table(schema, table_name) %}
+
+  {%- for col in cols -%}
+
+  {%- if col.column not in exclude -%}
+  select
+    {%- for exclude_col in exclude %}
+    {{ exclude_col }},
+    {%- endfor %}
+    '{{ col.column }}'::varchar as field_name,
+    {{ col.column }}::{{ cast_to }} as value
+  from {{ table }}
+  {% if not loop.last -%}
+  union all
+  {% endif -%}
+  {%- endif -%}
+  {%- endfor -%}
+{%- endmacro %}

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -32,8 +32,8 @@ Arguments:
     {%- for exclude_col in exclude %}
     {{ exclude_col }},
     {%- endfor %}
-    '{{ col.column }}'::varchar as field_name,
-    {{ col.column }}::{{ cast_to }} as value
+    cast('{{ col.column }}' as varchar) as field_name,
+    {{ dbt_utils.safe_cast(field={{ col.column }}, type={{ cast_to }}) }} as value
   from {{ table }}
   {% if not loop.last -%}
   union all


### PR DESCRIPTION
This macro adds functionality similar to pandas [melt](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.melt.html) function. It essentially "un-pivots" a table from wide-format to long-format. 