### PR TITLE
Star macro optional alias argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Usage:
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro.
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `alias` argument that will prefix all generated fields with a table alias.
 
 Usage:
 ```

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Usage:
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `alias` argument that will prefix all generated fields with a table alias.
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias.
 
 Usage:
 ```

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'dbt_utils_dwall'
+name: 'dbt_utils'
 version: '0.1.0'
 
 target-path: "target"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'dbt_utils'
+name: 'dbt_utils_dwall'
 version: '0.1.0'
 
 target-path: "target"

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,4 +1,4 @@
-{% macro star(from, except=[]) -%}
+{% macro star(from, alias=False, except=[]) -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
@@ -23,7 +23,7 @@
 
     {%- for col in include_cols %}
 
-        "{{ col }}" {% if not loop.last %},
+        {% if alias %} {{ alias }}.{% endif %}"{{ col }}" {% if not loop.last %},
         {% endif %}
 
     {%- endfor -%}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,4 +1,4 @@
-{% macro star(from, alias=False, except=[]) -%}
+{% macro star(from, relation_alias=False, except=[]) -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
@@ -23,7 +23,7 @@
 
     {%- for col in include_cols %}
 
-        {% if alias %} {{ alias }}.{% endif %}"{{ col }}" {% if not loop.last %},
+        {% if relation_alias %} {{ relation_alias }}.{% endif %}"{{ col }}" {% if not loop.last %},
         {% endif %}
 
     {%- endfor -%}


### PR DESCRIPTION
In the current implementation of the `star` macro, if you call the macro two distinct times referencing different tables that have overlapping field names, the model will error out since the `star` macro doesn't qualify the field names with a table alias (e.g. `ERROR:  column reference "column_name" is ambiguous`). This PR adds in an optional `relation_alias` argument to prefix all generated field names using `star` with an arbitrary table alias.