### PR TITLE
Add slug option to pivot macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Arguments:
     - column: Column name, required
     - values: List of row values to turn into columns, required
     - alias: Whether to create column aliases, default is True
+    - slug: Whether to slugify row values when generating column aliases, default is False
     - agg: SQL aggregation function, default is sum
     - cmp: SQL value comparison, default is =
     - prefix: Column alias prefix, default is blank

--- a/integration_tests/data/sql/data_pivot_slug.csv
+++ b/integration_tests/data/sql/data_pivot_slug.csv
@@ -1,0 +1,4 @@
+size,color
+S,Red Color
+S,Blue Color
+M,Red Color

--- a/integration_tests/data/sql/data_pivot_slug_expected.csv
+++ b/integration_tests/data/sql/data_pivot_slug_expected.csv
@@ -1,0 +1,3 @@
+size,red_color,blue_color
+S,1,1
+M,1,0

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,7 +5,7 @@ version: '1.0'
 profile: 'integration_tests'
 
 source-paths: ["models"]
-analysis-paths: ["analysis"] 
+analysis-paths: ["analysis"]
 test-paths: ["tests"]
 data-paths: ["data"]
 macro-paths: ["macros"]

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -41,6 +41,11 @@ test_pivot:
         dbt_utils.equality:
             - ref('data_pivot_expected')
 
+test_pivot_slug:
+    constraints:
+        dbt_utils.equality:
+            - ref('data_pivot_slug_expected')
+
 test_unpivot:
     constraints:
         dbt_utils.equality:

--- a/integration_tests/models/sql/test_pivot.sql
+++ b/integration_tests/models/sql/test_pivot.sql
@@ -2,16 +2,16 @@
 -- TODO: How do we make this work nicely on Snowflake too?
 
 {% if target.type == 'snowflake' %}
-    {% set column_values = ['RED', 'BLUE'] %}
+    {% set column_values = ['RED COLOR', 'BLUE COLOR'] %}
     {% set cmp = 'ilike' %}
 {% else %}
-    {% set column_values = ['red', 'blue'] %}
+    {% set column_values = ['Red Color', 'Blue Color'] %}
     {% set cmp = '=' %}
 {% endif %}
 
 select
     size,
-    {{ dbt_utils.pivot('color', column_values, cmp=cmp) }}
+    {{ dbt_utils.pivot('color', column_values, cmp=cmp, slug=True) }}
 
-from {{ ref('data_pivot') }}
+from {{ ref('data_pivot_slug') }}
 group by size

--- a/integration_tests/models/sql/test_pivot.sql
+++ b/integration_tests/models/sql/test_pivot.sql
@@ -2,16 +2,16 @@
 -- TODO: How do we make this work nicely on Snowflake too?
 
 {% if target.type == 'snowflake' %}
-    {% set column_values = ['RED COLOR', 'BLUE COLOR'] %}
+    {% set column_values = ['RED', 'BLUE'] %}
     {% set cmp = 'ilike' %}
 {% else %}
-    {% set column_values = ['Red Color', 'Blue Color'] %}
+    {% set column_values = ['red', 'blue'] %}
     {% set cmp = '=' %}
 {% endif %}
 
 select
     size,
-    {{ dbt_utils.pivot('color', column_values, cmp=cmp, slug=True) }}
+    {{ dbt_utils.pivot('color', column_values, cmp=cmp) }}
 
-from {{ ref('data_pivot_slug') }}
+from {{ ref('data_pivot') }}
 group by size

--- a/integration_tests/models/sql/test_pivot_slug.sql
+++ b/integration_tests/models/sql/test_pivot_slug.sql
@@ -1,0 +1,17 @@
+
+-- TODO: How do we make this work nicely on Snowflake too?
+
+{% if target.type == 'snowflake' %}
+    {% set column_values = ['RED COLOR', 'BLUE COLOR'] %}
+    {% set cmp = 'ilike' %}
+{% else %}
+    {% set column_values = ['Red Color', 'Blue Color'] %}
+    {% set cmp = '=' %}
+{% endif %}
+
+select
+    size,
+    {{ dbt_utils.pivot('color', column_values, cmp=cmp, slug=True) }}
+
+from {{ ref('data_pivot_slug') }}
+group by size

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -59,7 +59,7 @@ Arguments:
     )
     {% if alias %}
       {% if slug %}
-        {% let v = v|replace(' ', '_')|lower|trim %}
+        {% let v = v|trim|replace(' ', '_') %}
       {% endif %}
       as {{ adapter.quote(prefix ~ v ~ suffix) }}
     {% endif %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -59,7 +59,7 @@ Arguments:
     )
     {% if alias %}
       {% if slug %}
-        {% set v = v|trim|replace(' ', '_') %}
+        {% set v = v|trim|replace(' ', '_')|replace('-', '_')|lower %}
       {% endif %}
       as {{ adapter.quote(prefix ~ v ~ suffix) }}
     {% endif %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -59,7 +59,7 @@ Arguments:
     )
     {% if alias %}
       {% if slug %}
-        {% let v = v|trim|replace(' ', '_') %}
+        {% set v = v|trim|replace(' ', '_') %}
       {% endif %}
       as {{ adapter.quote(prefix ~ v ~ suffix) }}
     {% endif %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -30,6 +30,7 @@ Arguments:
     column: Column name, required
     values: List of row values to turn into columns, required
     alias: Whether to create column aliases, default is True
+    slug: Whether to slugify row values when generating column aliases, default is False
     agg: SQL aggregation function, default is sum
     cmp: SQL value comparison, default is =
     prefix: Column alias prefix, default is blank
@@ -41,6 +42,7 @@ Arguments:
 {% macro pivot(column,
                values,
                alias=True,
+               slug=False,
                agg='sum',
                cmp='=',
                prefix='',
@@ -56,6 +58,9 @@ Arguments:
       end
     )
     {% if alias %}
+      {% if slug %}
+        {% let v = v|replace(' ', '_')|lower|trim %}
+      {% endif %}
       as {{ adapter.quote(prefix ~ v ~ suffix) }}
     {% endif %}
     {% if not loop.last %},{% endif %}


### PR DESCRIPTION
# What

This P.R. adds a `slug` option to the `pivot` macro so that users can generate nicely formatted aliases for their pivoted columns. 

