### PR TITLE
casting timestamp to date for BQ

### DIFF
--- a/macros/cross_db_utils/dateadd.sql
+++ b/macros/cross_db_utils/dateadd.sql
@@ -17,7 +17,7 @@
 {% macro bigquery__dateadd(datepart, interval, from_date_or_timestamp) %}
 
     date_add(
-        {{ from_date_or_timestamp }},
+        cast( {{ from_date_or_timestamp }} as date),
         interval {{ interval }} {{ datepart }}
         )
 


### PR DESCRIPTION
Current iteration produces 

No matching signature for function DATE_ADD for argument types: TIMESTAMP, INTERVAL INT64 DATE_TIME_PART. Supported signature: DATE_ADD(DATE, INTERVAL INT64 DATE_TIME_PART)