### PR TITLE
Feature: get url path macro

### DIFF
--- a/integration_tests/data/web/data_url_path.csv
+++ b/integration_tests/data/web/data_url_path.csv
@@ -1,0 +1,4 @@
+original_url,parsed_path
+www.google.co.uk?utm_source=google&utm_medium=cpc&utm_campaign=spring-summer,
+http://witanddelight.com/2018/01/tips-tricks-how-run-half-marathon-first-time/,2018/01/tips-tricks-how-run-half-marathon-first-time/
+https://www.nytimes.com/2018/01/01/blog,2018/01/01/blog

--- a/integration_tests/models/web/schema.yml
+++ b/integration_tests/models/web/schema.yml
@@ -7,8 +7,13 @@ models:
           actual: actual
           expected: expected
           
-models:
   - name: test_url_host
+    tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
+          
+  - name: test_url_path
     tests:
       - assert_equal:
           actual: actual

--- a/integration_tests/models/web/test_url_path.sql
+++ b/integration_tests/models/web/test_url_path.sql
@@ -1,0 +1,12 @@
+with data as (
+    
+    select * from {{ref('data_url_path')}}
+    
+)
+
+select
+
+    {{ dbt_utils.get_url_path('original_url') }} as actual,
+    parsed_path as expected
+    
+from data

--- a/macros/web/get_url_path.sql
+++ b/macros/web/get_url_path.sql
@@ -1,0 +1,26 @@
+{% macro get_url_path(field) -%}
+
+
+{%- set stripped_url = 
+    dbt_utils.replace(dbt_utils.replace(field, "'http://'", "''"), "'https://'", "''")
+    
+%}
+
+{%- set first_slash_pos = 
+    dbt_utils.position("'/'", stripped_url)
+    
+%}
+
+{%- set parsed_path =
+    dbt_utils.split_part(
+        dbt_utils.right(stripped_url, dbt_utils.length(stripped_url) ~ "-" ~ first_slash_pos
+    ), "'?'", 1)
+-%}
+
+    {{ dbt_utils.safe_cast(
+        parsed_path,
+        dbt_utils.type_string()
+    )}}
+    
+{%- endmacro %}
+


### PR DESCRIPTION
* created `get_url_path` macro (broken up in three steps):
  - `stripped_url` replaces the `http://` or `https://` protocol with a blank space
  - `first_slash_pos` references `stripped_url` and uses the `position` macro to find where the first `/` is located in the URL
  - `parsed_path` uses the `split_part` and `right` macro, and subtracts the length of the URL with the `first_slash_pos`, returning everything to the right of the stripped URL and before the first `?`

* added seed file and test model for `get_url_path`
* updated `schema.yml` for test model

ISSUES:
* Right now, this macro doesn't take into consideration URLs that don't have a `/` in the URL after the host. 
  - For example, if a URL is as follows: `www.google.com?utm_source=google&utm_medium=cpc`, the macro is supposed to return <i>null</i>, however, because it looks for whatever is before the first '?', it returns `www.google.com` (which is the host, and that's not right)

* Besides this, BigQuery does not like the subtraction part of the logic below:
```
 {%- set parsed_path =
     dbt_utils.split_part(
         dbt_utils.right(stripped_url, dbt_utils.length(stripped_url) ~ "-" ~ first_slash_pos
     ), "'?'", 1)
 -%}
```
* for some reason, only with BigQuery, replacing the "-" with addition "+" returns exactly what we want (apart from question mark situation, which is not working for any of the databases)