### PR TITLE
Remove try_cast

### DIFF
--- a/macros/cross_db_utils/safe_cast.sql
+++ b/macros/cross_db_utils/safe_cast.sql
@@ -10,11 +10,6 @@
 {% endmacro %}
 
 
-{% macro snowflake__safe_cast(field, type) %}
-    try_cast({{field}} as {{type}})
-{% endmacro %}
-
-
 {% macro bigquery__safe_cast(field, type) %}
     safe_cast({{field}} as {{type}})
 {% endmacro %}


### PR DESCRIPTION
Per issue #89 `try_cast` only works on strings (https://docs.snowflake.net/manuals/sql-reference/functions/try_cast.html). As a result, this is causing errors in other macros (eg `union_tables`)