### PR TITLE
fix errant uses of safe_cast

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,8 @@ jobs:
             cd integration_tests
             dbt deps --target snowflake
             dbt seed --target snowflake --full-refresh
-            dbt run --target snowflake --exclude test_unpivot
-            dbt test --target snowflake --exclude test_unpivot
+            dbt run --target snowflake
+            dbt test --target snowflake
 
       - run:
           name: "Run Tests - BigQuery"

--- a/integration_tests/data/sql/data_union_expected.csv
+++ b/integration_tests/data/sql/data_union_expected.csv
@@ -1,6 +1,6 @@
-id,name,favorite_color
-1,"drew",
-2,"bob",
-3,"alice",
-1,,"green"
-2,,"pink"
+id,name,favorite_color,favorite_number
+1,"drew",,pi
+2,"bob",,e
+3,"alice",,4
+1,,"green",7
+2,,"pink",13

--- a/integration_tests/data/sql/data_union_table_1.csv
+++ b/integration_tests/data/sql/data_union_table_1.csv
@@ -1,4 +1,4 @@
-id,name
-1,drew
-2,bob
-3,alice
+id,name,favorite_number
+1,drew,pi
+2,bob,e
+3,alice,4

--- a/integration_tests/data/sql/data_union_table_2.csv
+++ b/integration_tests/data/sql/data_union_table_2.csv
@@ -1,3 +1,3 @@
-id,favorite_color
-1,green
-2,pink
+id,favorite_color,favorite_number
+1,green,7
+2,pink,13

--- a/integration_tests/models/sql/test_unpivot.sql
+++ b/integration_tests/models/sql/test_unpivot.sql
@@ -1,6 +1,29 @@
-{{ dbt_utils.unpivot(
-    table=ref('data_unpivot'), 
-    cast_to=dbt_utils.type_string(), 
-    exclude=['customer_id','created_at']
 
-) }}
+-- snowflake messes with these tests pretty badly since the
+-- output of the macro considers the casing of the source
+-- table columns. Using some hacks here to get this to work,
+-- but we should consider lowercasing the unpivot macro output
+-- at some point in the future for consistency
+
+{% if target.name == 'snowflake' %}
+    {% set exclude = ['CUSTOMER_ID', 'CREATED_AT'] %}
+{% else %}
+    {% set exclude = ['customer_id', 'created_at'] %}
+{% endif %}
+
+select
+    customer_id,
+    created_at,
+    case
+        when '{{ target.name }}' = 'snowflake' then lower(field_name)
+        else field_name
+    end as field_name,
+    value
+
+from (
+    {{ dbt_utils.unpivot(
+        table=ref('data_unpivot'),
+        cast_to=dbt_utils.type_string(),
+        exclude=exclude
+    ) }}
+) as sbq

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -56,15 +56,14 @@
         (
             select
 
-                {{ dbt_utils.safe_cast(dbt_utils.string_literal(table), dbt_utils.type_string()) }} as _dbt_source_table,
+                cast({{ dbt_utils.string_literal(table) }} as {{ dbt_utils.type_string() }}) as _dbt_source_table,
 
                 {% for col_name in ordered_column_names -%}
 
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
                     {%- set col_name = adapter.quote(col_name) if col_name in table_columns[table] else 'null' %}
-
-                    {{ dbt_utils.safe_cast(col_name, col_type) }} as {{ col.quoted }} {% if not loop.last %},{% endif %}
+                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif %}
                 {%- endfor %}
 
             from {{ table }}

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -28,7 +28,7 @@ Arguments:
   {%- set cols = adapter.get_columns_in_table(schema, table_name) %}
 
   {%- for col in cols -%}
-    {%- if col.column not in exclude -%}
+    {%- if col.column.lower() not in exclude|map('lower') -%}
       {% set _ = include_cols.append(col) %}
     {%- endif %}
   {%- endfor %}
@@ -40,7 +40,7 @@ Arguments:
         {{ exclude_col }},
       {%- endfor %}
       cast('{{ col.column }}' as {{ dbt_utils.type_string() }}) as field_name,
-      {{ dbt_utils.safe_cast(field=col.column, type=cast_to) }} as value
+      cast({{ col.column }} as {{ cast_to }}) as value
     from {{ table }}
     {% if not loop.last -%}
       union all


### PR DESCRIPTION
- do not use `safe_cast` when inappropriate ([see here](https://github.com/fishtown-analytics/dbt-utils/pull/112#issuecomment-452946608)) (union_tables, unpivot)
- improve `union_tables` integration test
- fix `union_tables` for Snowflake
- add `unpivot` integration test -- this was _disabled_ before, which was terrible

Note that this changes the behavior of `unpivot` slightly. Duplicate column names with different casing are no longer permitted, but I think that's a fair assumption to make.