### PR TITLE
Feature/union src column

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,14 +239,15 @@ from {{ref('my_model')}}
 ```
 
 #### union_tables ([source](macros/sql/union.sql))
-This macro implements an "outer union." The list of tables provided to this macro will be unioned together, and any columns exclusive to a subset of these tables will be filled with `null` where not present. The `column_override` argument is used to explicitly assign the column type for a set of columns.
+This macro implements an "outer union." The list of tables provided to this macro will be unioned together, and any columns exclusive to a subset of these tables will be filled with `null` where not present. The `column_override` argument is used to explicitly assign the column type for a set of columns. The `source_column_name` argument is used to change the name of the`_dbt_source_table` field.
 
 Usage:
 ```
 {{ dbt_utils.union_tables(
     tables=[ref('table_1'), ref('table_2')],
     column_override={"some_field": "varchar(100)"},
-    exclude=["some_other_field"]
+    exclude=["some_other_field"],
+    source_column_name='custom_source_column_name'
 ) }}
 ```
 

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,4 +1,4 @@
-{% macro union_tables(tables, column_override=none, exclude=none) -%}
+{% macro union_tables(tables, column_override=none, exclude=none, source_column_name=none) -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
@@ -7,6 +7,7 @@
 
     {%- set exclude = exclude if exclude is not none else [] %}
     {%- set column_override = column_override if column_override is not none else {} %}
+    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_table' %}
 
     {%- set table_columns = {} %}
     {%- set column_superset = {} %}
@@ -56,7 +57,7 @@
         (
             select
 
-                cast({{ dbt_utils.string_literal(table) }} as {{ dbt_utils.type_string() }}) as _dbt_source_table,
+                cast({{ dbt_utils.string_literal(table) }} as {{ dbt_utils.type_string() }}) as {{ source_column_name }},
 
                 {% for col_name in ordered_column_names -%}
 


### PR DESCRIPTION
Adding a new parameter to the union_tables macro to allow for customization of the `dbt_source_table` column. Updated README to reflect this as well. No new tests were added since the behavior of the function remains the same otherwise.