### PR TITLE
Add intersect macro

### DIFF
--- a/macros/cross_db_utils/intersect.sql
+++ b/macros/cross_db_utils/intersect.sql
@@ -1,0 +1,16 @@
+{% macro intersect() %}
+  {{ adapter_macro('dbt_utils.intersect') }}
+{% endmacro %}
+
+
+{% macro default__intersect() %}
+
+    intersect
+
+{% endmacro %}
+
+{% macro bigquery__intersect() %}
+
+    intersect distinct
+
+{% endmacro %}


### PR DESCRIPTION
I want to use this macro in the new dbt-audit-helper package, [here](https://github.com/fishtown-analytics/dbt-audit-helper/blob/master/macros/check_equality.sql#L46). Currently I'm installing from a branch to get it to work (see [here](https://github.com/fishtown-analytics/dbt-audit-helper/blob/master/packages.yml))