### PR TITLE
Added float and bigint datatype conversions

### DIFF
--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -65,3 +65,17 @@
 {% macro bigquery__type_bigint() %}
     int64
 {% endmacro %}
+
+{# int  -------------------------------------------------     #}
+
+{% macro type_int() %}
+  {{ adapter_macro('dbt_utils.type_int') }}
+{% endmacro %}
+
+{% macro default__type_int() %}
+    int
+{% endmacro %}
+
+{% macro bigquery__type_int() %}
+    int64
+{% endmacro %}

--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -35,3 +35,33 @@
 {% macro snowflake__type_timestamp() %}
     timestamp_ntz
 {% endmacro %}
+
+
+{# float  -------------------------------------------------     #}
+
+{% macro type_float() %}
+  {{ adapter_macro('dbt_utils.type_float') }}
+{% endmacro %}
+
+{% macro default__type_float() %}
+    float
+{% endmacro %}
+
+{% macro bigquery__type_float() %}
+    float64
+{% endmacro %}
+
+
+{# bigint  -------------------------------------------------     #}
+
+{% macro type_bigint() %}
+  {{ adapter_macro('dbt_utils.type_bigint') }}
+{% endmacro %}
+
+{% macro default__type_bigint() %}
+    bigint
+{% endmacro %}
+
+{% macro bigquery__type_bigint() %}
+    int64
+{% endmacro %}


### PR DESCRIPTION
Added the following cross db macros.
* type_float
* type_bigint
* type_int

We needed these macros to be build cross compatibility with Redshift and BigQuery.

