### PR TITLE
Point to hub for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
 This [dbt](https://github.com/fishtown-analytics/dbt) package contains macros that can be (re)used across dbt projects.
 
-## Getting started
-
-To use dbt-utils:
-
-1. Reference the package in your dbt project by creating a `packages.yml` file, which should look something like:
-
-  ```
-  packages:
-    - git: "https://github.com/fishtown-analytics/dbt-utils.git"
-      revision: 0.1.23
-  ```
-The revision key pins the dependency on a specific release of dbt-utils. Consult the [releases](https://github.com/fishtown-analytics/dbt-utils/releases) for information about the latest release.
-
-2. Install the package by executing `dbt deps`
-
-Detailed information on packages can be found in dbt's documentation in the [Package Management](https://docs.getdbt.com/docs/package-management) section.
+## Installation Instructions
+Check [dbt Hub](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/) for the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 
 ----
 


### PR DESCRIPTION
These installation instructions are notably much lighter than what was here before, since I've also opened a [PR](https://github.com/fishtown-analytics/hub.getdbt.com/pull/120) on the Hub site to add some instructions there.

If you're happy with this copy, I'll use it across all the packages we have on Hub – so expect lots of similar PRs :)

One thing to consider is that when you view this README on the hub site, it will have two sets of installation instructions 🤷‍♀ 