### PR TITLE
support extra parameter 'condition' on 'expression_is_true' macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ models:
 
 ```
 
+The macro accepts an optional parameter `condition` that allows for asserting
+the `expression` on a subset of all records.
+
+Usage:
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    tests:
+      - dbt_utils.expression_is_true:
+          expression: "col_a + col_b = total"
+          condition: "created_at > '2018-12-31'"
+
+```
+
+
 #### recency ([source](macros/schema_tests/recency.sql))
 This schema test asserts that there is data in the referenced model at least as recent as the defined interval prior to the current timestamp.
 

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -17,7 +17,10 @@ models:
     tests:
       - dbt_utils.expression_is_true:
           expression: col_a + col_b = 1
-        
+      - dbt_utils.expression_is_true:
+          expression: col_a = 0.5
+          condition: col_b = 0.5
+
   - name: test_recency
     tests:
       - dbt_utils.recency:

--- a/macros/schema_tests/expression_is_true.sql
+++ b/macros/schema_tests/expression_is_true.sql
@@ -1,7 +1,6 @@
-{% macro test_expression_is_true(model) %}
+{% macro test_expression_is_true(model, condition='true') %}
 
 {% set expression = kwargs.get('expression', kwargs.get('arg')) %}
-{% set condition = kwargs.get('condition', 'true') %}
 
 with meet_condition as (
 

--- a/macros/schema_tests/expression_is_true.sql
+++ b/macros/schema_tests/expression_is_true.sql
@@ -1,12 +1,18 @@
 {% macro test_expression_is_true(model) %}
 
 {% set expression = kwargs.get('expression', kwargs.get('arg')) %}
+{% set condition = kwargs.get('condition', 'true') %}
 
-with validation_errors as (
+with meet_condition as (
+
+    select * from {{ model }} where {{ condition }}
+
+),
+validation_errors as (
 
     select
         *
-    from {{model}}
+    from meet_condition
     where not({{expression}})
 
 )


### PR DESCRIPTION
An optional parameter 'condition' can be passed to the 
'expression_is_true' macro to assert the expression for all records 
which meet a condition. Closes #146

**Checklist**
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the [Fishtown Analytics style guide](https://github.com/fishtown-analytics/corp/blob/master/dbt_coding_conventions.md).
- [X] I have added appropriate tests and documentation to any new models.
- [x] I have updated the README file.