### PR TITLE
Fix for pretty logger integration tests

### DIFF
--- a/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_log_format() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 where false
+    select 1 limit 0
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_time_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_time_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_time() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 where false
+    select 1 limit 0
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1


### PR DESCRIPTION
- use `limit 0` instead of `where false`