### PR TITLE
Fix/get column values

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,14 @@ This macro "un-pivots" a table from wide format to long format. Functionality is
 
 Usage:
 ```
-{{ dbt_utils.unpivot(table=ref('table_name'), cast_to='datatype', exclude=[<list of columns to exclude from unpivot>], remove=[<list of columns to remove>], field_name=<column name for field>, value_name=<column name for value>) }}
+{{ dbt_utils.unpivot(
+  table=ref('table_name'),
+  cast_to='datatype',
+  exclude=[<list of columns to exclude from unpivot>],
+  remove=[<list of columns to remove>],
+  field_name=<column name for field>,
+  value_name=<column name for value>
+) }}
 ```
 
 Example:

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Usage:
 
 Example:
 
-    Input: public.test
+    Input: orders
 
     | size | color |
     |------|-------|
@@ -311,9 +311,11 @@ Example:
 
     select
       size,
-      {{ dbt_utils.pivot('color', dbt_utils.get_column_values('public.test',
-                                                             'color')) }}
-    from public.test
+      {{ dbt_utils.pivot(
+          'color',
+          dbt_utils.get_column_values(ref('orders'), 'color')
+      ) }}
+    from {{ ref('orders') }}
     group by size
 
     Output:

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ models:
 ---
 ### SQL helpers
 #### get_column_values ([source](macros/sql/get_column_values.sql))
-This macro returns the unique values for a column in a given table.
-It takes an options `default` argument for compiling when relation does not already exist. 
+This macro returns the unique values for a column in a given [relation](https://docs.getdbt.com/docs/api-variable#section-relation).
+It takes an options `default` argument for compiling when the relation does not already exist.
 
 Usage:
 ```

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -18,9 +18,7 @@ Returns:
     {% endif %}
 {#--  #}
 
-    {%- set target_relation = adapter.get_relation(database=table.database,
-                                          schema=table.schema,
-                                         identifier=table.identifier) -%}
+    {%- set target_relation = table -%}
 
     {%- call statement('get_column_values', fetch_result=true) %}
 

--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -18,7 +18,9 @@ Returns:
     {% endif %}
 {#--  #}
 
-    {%- set target_relation = table -%}
+    {%- set target_relation = adapter.get_relation(database=table.database,
+                                          schema=table.schema,
+                                         identifier=table.identifier) -%}
 
     {%- call statement('get_column_values', fetch_result=true) %}
 


### PR DESCRIPTION
Fixes #153 
I've left the argument name as `table` – this terminology is used consistently throughout utils (e.g. `get_tables_by_prefix`, `union_tables`, `unpivot`), so if we want to fix that, we should do it as a separate PR to fix all of them.