### PR TITLE
Add get_column_names_from_sql macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This macro is useful when you need to iterate through columns in a CTE (includin
 {% set query_sql %}
 select * from {{ ref('my_ephemeral_model') }}
 {% endset %}
-{% set column_names=get_columns_in_relation(query_sql) %}
+{% set column_names=get_column_names_from_sql(query_sql) %}
 
 select
 {% for column_name in column_names %}

--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ Usage:
 ...
 ```
 
+#### get_column_names_from_sql ([source](macros/sql/get_column_names_from_sql.sql))
+This macro returns a list of column names (_not_ `Column`[objects](https://docs.getdbt.com/docs/api-variable#section-column)) for the results of a provided query.
+
+This macro is useful when you need to iterate through columns in a CTE (including an ephemeral model) since the information_schema cannot be queried. If you need to find the columns in a [Relation](https://docs.getdbt.com/docs/api-variable#section-relation) (generally a table or view), you should use [get_columns_in_relation](https://docs.getdbt.com/docs/adapter#section-get_columns_in_relation) instead.
+
+```sql
+{% set query_sql %}
+select * from {{ ref('my_ephemeral_model') }}
+{% endset %}
+{% set column_names=get_columns_in_relation(query_sql) %}
+
+select
+{% for column_name in column_names %}
+  {{ column_name }} as my_{{ column_name }} {{ ", " if not loop.last }}
+{% endfor %}
+from {{ ref('my_ephemeral_model') }}
+
+```
 #### get_tables_by_prefix ([source](macros/sql/get_tables_by_prefix.sql))
 This macro returns a list of tables that match a given prefix, with an optional
 exclusion pattern. It's particularly handy paired with `union_tables`.

--- a/integration_tests/tests/sql/test_get_column_names_from_sql.sql
+++ b/integration_tests/tests/sql/test_get_column_names_from_sql.sql
@@ -3,7 +3,7 @@
 
 
 {% if target.type in ('snowflake') %}
-    {% do expected_columns.upper() %}
+{% set expected_columns=('COL_A', 'COL_B') %}
 {% endif %}
 
 {% set query_sql="select 1 as col_a, 2 as col_b limit 1" %}

--- a/integration_tests/tests/sql/test_get_column_names_from_sql.sql
+++ b/integration_tests/tests/sql/test_get_column_names_from_sql.sql
@@ -1,0 +1,17 @@
+
+{% set expected_columns=('col_a', 'col_b') %}
+
+
+{% if target.type in ('snowflake') %}
+    {% do expected_columns.upper() %}
+{% endif %}
+
+{% set query_sql="select 1 as col_a, 2 as col_b limit 1" %}
+
+{% set actual_columns=dbt_utils.get_column_names_from_sql(query_sql) %}
+
+{% if actual_columns == expected_columns %}
+select 1 limit 0
+{% else %}
+select 1
+{% endif %}

--- a/macros/sql/get_column_names_from_sql.sql
+++ b/macros/sql/get_column_names_from_sql.sql
@@ -1,0 +1,31 @@
+{#-
+This query returns a list of column names. This is particularly useful when you
+need the column names from a CTE (e.g. an ephemeral model), rather than a relation
+(i.e. a view or table) since the
+Note that it only returns column_names, and not a Column object
+-#}
+{%- macro get_column_names_from_sql(query_sql) -%}
+
+{%- set query_sql_limit_0 -%}
+with query_sql as (
+    {{ query_sql }}
+)
+
+select * from query_sql
+limit 0
+
+{%- endset -%}
+
+{%- set results = run_query(query_sql_limit_0) -%}
+
+{%- if execute -%}
+
+{{- return(results.column_names) -}}
+
+{%- else -%}
+
+{{- return([]) -}}
+
+{%- endif -%}
+
+{%- endmacro -%}


### PR DESCRIPTION
Inspired by a Slack thread, didn't want to lose it.

I've wanted this before, but have always worked around it by creating things as views upstream.

TBH I'm not sure of the utility of it unless we work it into `union` and `star` so that both work with upstream ephemeral models.