### PR TITLE
Add whitelist to union_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,14 @@ from {{ref('my_model')}}
 #### union_tables ([source](macros/sql/union.sql))
 This macro implements an "outer union." The list of relations provided to this macro will be unioned together, and any columns exclusive to a subset of these tables will be filled with `null` where not present. The `column_override` argument is used to explicitly assign the column type for a set of columns. The `source_column_name` argument is used to change the name of the`_dbt_source_table` field.
 
+The arguments `include` and `exclude` can be provided to whitelist or blacklist columns respectively. `exclude` takes precidence if a column is specified in both `include` and `exclude`.
+
 Usage:
 ```
 {{ dbt_utils.union_tables(
     tables=[ref('table_1'), ref('table_2')],
     column_override={"some_field": "varchar(100)"},
+    include=["some_included_field"],
     exclude=["some_other_field"],
     source_column_name='custom_source_column_name'
 ) }}
@@ -326,7 +329,7 @@ Example:
     Input: orders
 
     | size | color |
-    |------|-------|
+    | ---- | ----- |
     | S    | red   |
     | S    | blue  |
     | S    | red   |
@@ -344,7 +347,7 @@ Example:
     Output:
 
     | size | red | blue |
-    |------|-----|------|
+    | ---- | --- | ---- |
     | S    | 2   | 1    |
     | M    | 1   | 0    |
 
@@ -381,7 +384,7 @@ Example:
     Input: orders
 
     | date       | size | color | status     |
-    |------------|------|-------|------------|
+    | ---------- | ---- | ----- | ---------- |
     | 2017-01-01 | S    | red   | complete   |
     | 2017-03-01 | S    | red   | processing |
 
@@ -390,7 +393,7 @@ Example:
     Output:
 
     | date       | status     | field_name | value |
-    |------------|------------|------------|-------|
+    | ---------- | ---------- | ---------- | ----- |
     | 2017-01-01 | complete   | size       | S     |
     | 2017-01-01 | complete   | color      | red   |
     | 2017-03-01 | processing | size       | S     |

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,10 +1,11 @@
-{% macro union_tables(tables, column_override=none, exclude=none, source_column_name=none) -%}
+{% macro union_tables(tables, column_override=none, include=none, exclude=none, source_column_name=none) -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {{ return('') }}
     {% endif %}
 
+    {%- set include = include if include is not none else [] %}
     {%- set exclude = exclude if exclude is not none else [] %}
     {%- set column_override = column_override if column_override is not none else {} %}
     {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_table' %}
@@ -20,6 +21,7 @@
         {%- set cols = adapter.get_columns_in_relation(table) %}
         {%- for col in cols -%}
 
+        {%- if include|length == 0 or col.column in include %}
         {%- if col.column not in exclude %}
 
             {# update the list of columns in this table #}
@@ -40,6 +42,7 @@
 
             {%- endif -%}
 
+        {%- endif -%}
         {%- endif -%}
 
         {%- endfor %}


### PR DESCRIPTION
Support `include` column list on the `union_all` macro.

Fixes https://github.com/fishtown-analytics/dbt-utils/issues/90