### PR TITLE
Fixes date_spine for BigQuery

### DIFF
--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -79,3 +79,30 @@
 {% macro bigquery__type_int() %}
     int64
 {% endmacro %}
+
+{# datetime  -------------------------------------------------     #}
+
+{%- macro type_datetime() -%}
+  {{ adapter_macro('dbt_utils.type_datetime') }}
+{%- endmacro -%}
+
+{%- macro default__type_datetime() -%}
+    datetime
+{%- endmacro -%}
+
+{%- macro bigquery__type_datetime() -%}
+    datetime
+{%- endmacro -%}
+
+{%- macro redshift__type_datetime() -%}
+    datetime
+{%- endmacro -%}
+
+{%- macro postgres__type_datetime() -%}
+    datetime
+{%- endmacro -%}
+
+{%- macro snowflake__type_datetime() -%}
+    datetime
+{%- endmacro -%}
+

--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -89,20 +89,3 @@
 {%- macro default__type_datetime() -%}
     datetime
 {%- endmacro -%}
-
-{%- macro bigquery__type_datetime() -%}
-    datetime
-{%- endmacro -%}
-
-{%- macro redshift__type_datetime() -%}
-    datetime
-{%- endmacro -%}
-
-{%- macro postgres__type_datetime() -%}
-    datetime
-{%- endmacro -%}
-
-{%- macro snowflake__type_datetime() -%}
-    datetime
-{%- endmacro -%}
-

--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -19,7 +19,7 @@
 
 {# private, don't call from anywhere else #}
 {%- macro date_spine__parse_end_date(end_date) -%}
-  {{ adapter_macro('dbt_utils.prep_end_date_', end_date) }}
+  {{ adapter_macro('dbt_utils.date_spine__parse_end_date', end_date) }}
 {%- endmacro -%}
 
 

--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -60,7 +60,7 @@ filtered as (
 
     select *
     from all_periods
-    where date_{{datepart}} <= {{ end_date }}
+    where date_{{datepart}} <= {{ dbt_utils.safe_cast(end_date, dbt_utils.datatypes.datetime()) }}
 
 )
 

--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -60,7 +60,7 @@ filtered as (
 
     select *
     from all_periods
-    where date_{{datepart}} <= {{ dbt_utils.safe_cast(end_date, dbt_utils.datatypes.datetime()) }}
+    where date_{{datepart}} <= {{ dbt_utils.safe_cast(end_date, dbt_utils.type_datetime()) }}
 
 )
 

--- a/macros/datetime/date_spine.sql
+++ b/macros/datetime/date_spine.sql
@@ -17,7 +17,20 @@
 
 {%- endmacro %}
 
+{# private, don't call from anywhere else #}
+{%- macro date_spine__parse_end_date(end_date) -%}
+  {{ adapter_macro('dbt_utils.prep_end_date_', end_date) }}
+{%- endmacro -%}
 
+
+{%- macro default__date_spine__parse_end_date(end_date) -%}
+    {{ end_date }}
+{%- endmacro -%}
+
+
+{%- macro bigquery__date_spine__parse_end_date(end_date) -%}
+    {{ dbt_utils.safe_cast(end_date, dbt_utils.type_datetime()) }}
+{%- endmacro -%}
 
 
 {% macro date_spine(datepart, start_date, end_date) %}
@@ -60,7 +73,7 @@ filtered as (
 
     select *
     from all_periods
-    where date_{{datepart}} <= {{ dbt_utils.safe_cast(end_date, dbt_utils.type_datetime()) }}
+    where date_{{datepart}} <= {{ dbt_utils.date_spine__parse_end_date(end_date) }}
 
 )
 


### PR DESCRIPTION
This addresses the datatype issue when calling `date_spine` from BigQuery. See #120 
I've also added `datetime` to `dbt_utils.datatypes()` in case some (future) platforms have requirements or names for this.

You still have to call `date_spine` with parameters that _can_ be cast to a `datetime`, so either dates, strings or datetimes. 

So, this (from the README) still works:
```
{{ dbt_utils.date_spine(
    datepart="minute",
    start_date="to_date('01/01/2016', 'mm/dd/yyyy')",
    end_date="dateadd(week, 1, current_date)"
   )
}}
```

But I don't think something like _this_ would work:
```
{{ dbt_utils.date_spine(
    datepart="minute",
    start_date="2016-01-01",
    end_date="2022-12-31"
   )
}}
```
since those start/end dates would need be wrapped in quotes (`'`) to be parsed as strings. Not sure this is something we need to address.