### PR TITLE
Feature: add uniqueness_test option to cardinality equality test

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ models:
 ```
 
 #### cardinality_equality ([source](macros/schema_tests/cardinality_equality.sql))
-This schema test asserts if values in a given column have exactly the same cardinality as values from a different column in a different model.
+This schema test asserts if values in a given column have exactly the same cardinality as values from a different column in a different model. An option to test that the two columns share unique values is provided via the test_uniqueness option.
 
 Usage:
 ```yaml
@@ -209,6 +209,7 @@ models:
           - dbt_utils.cardinality_equality:
               field: other_column_name
               to: ref('other_model_name')
+              test_uniqueness: false
 
 ```
 

--- a/integration_tests/data/schema_tests/data_test_cardinality_uniqueness_test_table_1.csv
+++ b/integration_tests/data/schema_tests/data_test_cardinality_uniqueness_test_table_1.csv
@@ -1,0 +1,4 @@
+state
+ca
+il
+ny

--- a/integration_tests/data/schema_tests/data_test_cardinality_uniqueness_test_table_2.csv
+++ b/integration_tests/data/schema_tests/data_test_cardinality_uniqueness_test_table_2.csv
@@ -1,0 +1,5 @@
+state
+ca
+il
+ny
+ny

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -54,7 +54,7 @@ models:
     columns:
       - name: state
         tests:
-          - cardinality_equality:
+          - dbt_utils.cardinality_equality:
               field: state
               to: ref('test_cardinality_uniqueness_test_table_2')
               test_uniqueness: true

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -50,3 +50,12 @@ models:
               to: ref('data_test_relationships_where_table_1')
               field: id
               from_condition: id <> 4
+  - name: test_cardinality_uniqueness_test_table_1
+    columns:
+      - name: state
+        tests:
+          - cardinality_equality:
+              field: state
+              to: ref('test_cardinality_uniqueness_test_table_2')
+              test_uniqueness: true
+

--- a/integration_tests/models/schema_tests/test_cardinality_uniqueness_test_table_1.sql
+++ b/integration_tests/models/schema_tests/test_cardinality_uniqueness_test_table_1.sql
@@ -1,0 +1,9 @@
+with data as (
+
+    select * from {{ ref('data_test_cardinality_uniqueness_test_table_1') }}
+
+)
+
+select
+    state
+from data

--- a/integration_tests/models/schema_tests/test_cardinality_uniqueness_test_table_2.sql
+++ b/integration_tests/models/schema_tests/test_cardinality_uniqueness_test_table_2.sql
@@ -1,0 +1,9 @@
+with data as (
+
+    select * from {{ ref('data_test_cardinality_uniqueness_test_table_2') }}
+
+)
+
+select
+    state
+from data

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -1,22 +1,26 @@
-{% macro test_cardinality_equality(model, to, field) %}
+{% macro test_cardinality_equality(model, to, field, test_uniqueness=false) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
 
 
 with table_a as (
-select
-  {{ column_name }},
-  count(*) as num_rows
-from {{ model }}
-group by 1
+  select
+      {{ column_name }}
+  {%- if test_uniqueness == false -%}
+     , count(*) as num_rows
+  {%- endif %}
+  from {{ model }}
+  group by 1
 ),
 
 table_b as (
-select
-  {{ field }},
-  count(*) as num_rows
-from {{ to }}
-group by 1
+  select
+      {{ field }}
+  {%- if test_uniqueness == false -%}
+     , count(*) as num_rows
+  {%- endif %}
+  from {{ to }}
+  group by 1
 ),
 
 except_a as (
@@ -47,3 +51,5 @@ select count(*)
 from unioned
 
 {% endmacro %}
+
+


### PR DESCRIPTION
I needed something somewhere in between the relationship test and this cardinality test.

The test needed to compare the unique values across two different sources' models to ensure that the unique values were in lock-step across both systems. The current test fails if the total count of rows was different even if the distinct values were shared.

Technically having two relationship tests  (one pointing from A->B and one from B->A) would work, but I like the convenience of being able to run just one test.

This is my first attempt at forking a public repo and trying to contribute, let me know if I did anything wrong or missed a step.