### PR TITLE
Add a new schema test: numeric_constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,50 @@ models:
 
 ```
 
+#### numeric_constraints ([source](macros/schema_tests/numeric_constraints.sql))
+This schema test asserts that a column of numerical value is within specified bounds.
+
+Usage:
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    columns:
+      - name: a_number
+        tests:
+          - dbt_utils.numeric_constraints:
+              gte: 0
+              lt: 180
+```
+
+Possible options:
+```
+eq:   equal
+ne:   not equal
+gt:   greater than
+gte:  greater than or equal
+lt:   lower than
+lte:  lower than or equal
+```
+
+The macro accepts an optional parameter `condition` that allows for asserting
+the `expression` on a subset of all records.
+
+Usage:
+```yaml
+version: 2
+
+models:
+  - name: model_name
+    columns:
+      - name: a_number
+        tests:
+          - dbt_utils.numeric_constraints:
+              eq: 1
+              condition: "status = 'success'"
+
+```
 
 #### recency ([source](macros/schema_tests/recency.sql))
 This schema test asserts that there is data in the referenced model at least as recent as the defined interval prior to the current timestamp.

--- a/integration_tests/data/schema_tests/data_test_numeric_constraints.csv
+++ b/integration_tests/data/schema_tests/data_test_numeric_constraints.csv
@@ -1,0 +1,9 @@
+id,type,status,vat_pct
+1,national,done,0.19
+2,national,done,0.19
+3,national,done,0.07
+4,national,open,0.07
+5,international,done,0
+6,international,done,0
+7,international,done,0
+8,international,open,0.19

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -50,3 +50,15 @@ models:
               to: ref('data_test_relationships_where_table_1')
               field: id
               from_condition: id <> 4
+
+  - name: data_test_numeric_constraints
+    columns:
+      - name: vat_pct
+        tests:
+          - dbt_utils.numeric_constraints:
+              gte: 0
+              ne: 0.5
+              lt: 1
+          - dbt_utils.numeric_constraints:
+              eq: 0
+              condition: "(status = 'done') and (type = 'international')"

--- a/macros/schema_tests/numeric_constraints.sql
+++ b/macros/schema_tests/numeric_constraints.sql
@@ -1,0 +1,36 @@
+{% macro test_numeric_constraints(model, condition='true') %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set eq = kwargs.get('eq', kwargs.get('arg')) %}
+{% set ne = kwargs.get('ne', kwargs.get('arg')) %}
+{% set gt = kwargs.get('gt', kwargs.get('arg')) %}
+{% set gte = kwargs.get('gte', kwargs.get('arg')) %}
+{% set lt = kwargs.get('lt', kwargs.get('arg')) %}
+{% set lte = kwargs.get('lte', kwargs.get('arg')) %}
+
+
+with meet_condition as (
+
+    select * from {{ model }} where {{ condition }}
+
+),
+validation_errors as (
+
+    select
+        *
+    from meet_condition
+    where not (true
+      {% if eq is not none %} and {{column_name}} = {{ eq or 0 }} {% endif %}
+      {% if ne is not none %} and {{column_name}} <> {{ ne or 0 }} {% endif %}
+      {% if gt is not none %} and {{column_name}} > {{ gt or 0 }} {% endif %}
+      {% if gte is not none %} and {{column_name}} >= {{ gte or 0 }} {% endif %}
+      {% if lt is not none %} and {{column_name}} < {{ lt or 0 }} {% endif %}
+      {% if lte is not none %} and {{column_name}} <= {{ lte or 0 }} {% endif %}
+    )
+
+)
+
+select count(*)
+from validation_errors
+
+{% endmacro %}


### PR DESCRIPTION
Hi all!

This is my first pull request, so please forgive amateur mistakes (but do point them out ruthlessly!). I used [this PR](https://github.com/fishtown-analytics/dbt-utils/pull/161) as guidance on how to structure the PR.

To quote @MartinGuindon directly, I'm also submitting this PR to add a new schema test that has proven to be extremely useful.

Essentially, I want to be able to easily test numeric columns for values in various ways. For instance, I need to be sure that VAT values are indeed percentages within a certain range, or that VAT is zero for international transactions.

Thought I'd share it with you :)

Best,
Bijan