### PR TITLE
Reducing whitespace in group_by

### DIFF
--- a/macros/sql/groupby.sql
+++ b/macros/sql/groupby.sql
@@ -1,9 +1,8 @@
-{% macro group_by(n) %}
+{%- macro group_by(n) -%}
 
   group by
-    {% for i in range(1, n + 1) %}
-      {{ i }}
-      {% if not loop.last %} , {% endif %}
-   {% endfor %}
+    {% for i in range(1, n + 1) -%}
+      {{ i }}{{ ',' if not loop.last }}   
+   {%- endfor -%}
 
-{% endmacro %}
+{%- endmacro -%}

--- a/macros/sql/groupby.sql
+++ b/macros/sql/groupby.sql
@@ -1,7 +1,6 @@
 {%- macro group_by(n) -%}
 
-  group by
-    {% for i in range(1, n + 1) -%}
+  group by {% for i in range(1, n + 1) -%}
       {{ i }}{{ ',' if not loop.last }}   
    {%- endfor -%}
 


### PR DESCRIPTION
reducing whitespace in compiled SQL for legibility

select
    foo.a 
  , foo.b 
  , foo.c 
  , sum(foo.d)
from
  foo 
{{group_by(n=3)}} 


now results in 

select
    foo.a 
  , foo.b 
  , foo.c 
  , sum(foo.d)
from
  foo 
group by
    1,2,3