### PR TITLE
Add a compare_columns arg to the equality test

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ models:
 ```
 
 #### equality ([source](macros/schema_tests/equality.sql))
-This schema test asserts the equality of two relations.
+This schema test asserts the equality of two relations. Optionally specify a subset of columns to compare.
 
 Usage:
 ```yaml
@@ -110,6 +110,9 @@ models:
     tests:
       - dbt_utils.equality:
           compare_model: ref('other_table_name')
+          compare_columns:
+            - first_column
+            - second_column
 
 ```
 

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -33,6 +33,15 @@ models:
       - dbt_utils.equal_rowcount:
           compare_model: ref('test_equal_rowcount')
 
+  - name: test_equal_column_subset
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_people')
+          compare_columns:
+            - first_name
+            - last_name
+            - email
+
   - name: data_people
     columns:
       - name: is_active

--- a/integration_tests/models/schema_tests/test_equal_column_subset.sql
+++ b/integration_tests/models/schema_tests/test_equal_column_subset.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='ephemeral') }}
+
+select
+
+  first_name,
+  last_name,
+  email
+
+from {{ ref('data_people') }}


### PR DESCRIPTION
### Description
The `compare_columns` argument allows a user to specify a subset of
columns to compare when checking the equality of two models' data.

### Rationale
There are a few shortcomings of the previous implementation that this
helps to address. With the previous implementation:

- You cannot compare two ephemeral models, as the comparison depends
  on the ability to introspect relation.
- If two models differ in a predictable and expected way (e.g., the
  addition of a surrogate key column), you would have to create an
  additional materialized model that selects all but the added column
  in order to compare equality.