### PR TITLE
Reduce whitespace in dbt_utils.star

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,5 +1,5 @@
 {% macro star(from, relation_alias=False, except=[]) -%}
-    
+
     {%- do dbt_utils._is_relation(from, 'star') -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
@@ -19,8 +19,8 @@
 
     {%- for col in include_cols %}
 
-        {% if relation_alias %} {{ relation_alias }}.{% endif %} {{ dbt_utils.identifier(col) }} {% if not loop.last %},
-        {% endif %}
+        {%- if relation_alias %}{{ relation_alias }}.{% else %}{% endif %}{{ dbt_utils.identifier(col)|trim }}
+        {%- if not loop.last %},{{ '\n' }}{% endif %}
 
     {%- endfor -%}
 {%- endmacro %}


### PR DESCRIPTION
A call to `{{ dbt_utils.star(this, relation_alias='x') }}` previously would produce something like:

```
      

         x. 
  "column1"
 ,
        

         x. 
  "column2"
 ,
        

         x. 
  "column3"
```

Now produces:

```
x."column1",
x."column2",
x."column3"
```

The latter plays more nicely with the readability of the compiled sql. No leading or trailing whitespace, and just a newline between each column reference.