### PR TITLE
Replace references to tables to relations. Add include param to union

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,12 +357,12 @@ handy paired with `union_relations`.
 -- Returns a list of relations that match schema.prefix%
 {% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix') %}
 
--- Returns a list of relations as above, excluding any with underscores
-{% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix', '%_%') %}
+-- Returns a list of relations as above, excluding any that end in `_deprecated`
+{% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix', '%_deprecated') %}
 
 -- Example using the union_relations macro
 {% set event_relations = dbt_utils.get_relations_by_prefix('events', 'event_') %}
-{{ dbt_utils.union_relations(relations = union_relations) }}
+{{ dbt_utils.union_relations(relations = event_relations) }}
 ```
 
 **Args:**
@@ -412,7 +412,7 @@ relations will be filled with `null` where not present. An new column
 * `exclude` (optional): A list of column names that should be excluded from
 the final query.
 * `include` (optional): A list of column names that should be included in the
-final query. Note that you cannot provide both a whitelist and a blacklist.
+final query. Note the `include` and `exclude` parameters are mutually exclusive.
 * `column_override` (optional): A dictionary of explicit column type overrides,
 e.g. `{"some_field": "varchar(100)"}`.``
 * `source_column_name` (optional, `default="_dbt_source_relation"`): The name of

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ handy paired with `union_relations`.
 -- Returns a list of relations that match schema.prefix%
 {% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix') %}
 
--- Returns a list of relations as above, excluding any that end in `_deprecated`
-{% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix', '%_deprecated') %}
+-- Returns a list of relations as above, excluding any that end in `deprecated`
+{% set relations = dbt_utils.get_relations_by_prefix('my_schema', 'my_prefix', '%deprecated') %}
 
 -- Example using the union_relations macro
 {% set event_relations = dbt_utils.get_relations_by_prefix('events', 'event_') %}

--- a/integration_tests/models/sql/test_get_relations_by_prefix_and_union.sql
+++ b/integration_tests/models/sql/test_get_relations_by_prefix_and_union.sql
@@ -1,14 +1,4 @@
 {{ config(materialized = 'table') }}
 
-
-{% if target.type == 'snowflake' %}
-
-    {% set relations = dbt_utils.get_relations_by_prefix((target.schema | upper), 'data_events_') %}
-    {{ dbt_utils.union_relations(relations) }}
-
-{% else %}
-
-    {% set relations = dbt_utils.get_relations_by_prefix(target.schema, 'data_events_') %}
-    {{ dbt_utils.union_relations(relations) }}
-
-{% endif %}
+{% set relations = dbt_utils.get_relations_by_prefix(target.schema, 'data_events_') %}
+{{ dbt_utils.union_relations(relations) }}

--- a/integration_tests/models/sql/test_get_relations_by_prefix_and_union.sql
+++ b/integration_tests/models/sql/test_get_relations_by_prefix_and_union.sql
@@ -1,0 +1,14 @@
+{{ config(materialized = 'table') }}
+
+
+{% if target.type == 'snowflake' %}
+
+    {% set relations = dbt_utils.get_relations_by_prefix((target.schema | upper), 'data_events_') %}
+    {{ dbt_utils.union_relations(relations) }}
+
+{% else %}
+
+    {% set relations = dbt_utils.get_relations_by_prefix(target.schema, 'data_events_') %}
+    {{ dbt_utils.union_relations(relations) }}
+
+{% endif %}

--- a/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
+++ b/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
@@ -1,14 +1,4 @@
 {{config( materialized = 'table')}}
 
-
-{% if target.type == 'snowflake' %}
-
-    {% set tables = dbt_utils.get_tables_by_prefix((target.schema | upper), 'data_events_') %}
-    {{ dbt_utils.union_tables(tables) }}
-    
-{% else %}
-
-    {% set tables = dbt_utils.get_tables_by_prefix(target.schema, 'data_events_') %}
-    {{ dbt_utils.union_tables(tables) }}
-
-{% endif %}
+{% set tables = dbt_utils.get_tables_by_prefix(target.schema, 'data_events_') %}
+{{ dbt_utils.union_tables(tables) }}

--- a/integration_tests/models/sql/test_union_base.sql
+++ b/integration_tests/models/sql/test_union_base.sql
@@ -1,6 +1,5 @@
 
-{{ dbt_utils.union_tables([
+{{ dbt_utils.union_relations([
         ref('data_union_table_1'),
         ref('data_union_table_2')]
-) }} 
-
+) }}

--- a/integration_tests/models/sql/test_unpivot.sql
+++ b/integration_tests/models/sql/test_unpivot.sql
@@ -23,7 +23,7 @@ select
 
 from (
     {{ dbt_utils.unpivot(
-        table=ref('data_unpivot'),
+        relation=ref('data_unpivot'),
         cast_to=dbt_utils.type_string(),
         exclude=exclude,
         remove='name',

--- a/macros/sql/get_relations_by_prefix.sql
+++ b/macros/sql/get_relations_by_prefix.sql
@@ -1,4 +1,4 @@
-{% macro get_tables_by_prefix(schema, prefix, exclude='', database=target.database) %}
+{% macro get_relations_by_prefix(schema, prefix, exclude='', database=target.database) %}
 
     {%- call statement('get_tables', fetch_result=True) %}
 
@@ -14,11 +14,20 @@
             {%- set tbl_relation = api.Relation.create(database, row.table_schema, row.table_name) -%}
             {%- do tbl_relations.append(tbl_relation) -%}
         {%- endfor -%}
-                
+
         {{ return(tbl_relations) }}
     {%- else -%}
         {{ return([]) }}
     {%- endif -%}
-    
+
 {% endmacro %}
 
+{% macro get_tables_by_prefix(schema, prefix, exclude='', database=target.database) %}
+    {% if execute %}
+        {{ log("Warning: the `get_tables_by_prefix` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `get_relations_by_prefix` macro instead", info=True) }}
+    {% endif %}
+
+
+    {{ return(dbt_utils.get_relations_by_prefix(schema, prefix, exclude, database)) }}
+
+{% endmacro %}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -81,13 +81,12 @@
 
 {%- endmacro %}
 
-{% macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name=none) -%}
+{% macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_table') -%}
 
     {% if execute %}
         {{ log("Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `union_relations` macro instead", info=True) }}
     {% endif %}
 
-
-    {{ return(dbt_utils.union_relations(tables, column_override, include, exclude, source_column_name='_dbt_source_table')) }}
+    {{ return(dbt_utils.union_relations(tables, column_override, include, exclude, source_column_name)) }}
 
 {% endmacro %}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -26,7 +26,7 @@
         {#- If an exclude list was provided and the column is in the list, do nothing #}
         {%- if exclude and col.column in exclude %}
 
-        {#- If an include list was procided and the column is not in the list, do nothing -#}
+        {#- If an include list was provided and the column is not in the list, do nothing -#}
         {%- elif include and col.column not in include %}
 
         {#- Otherwise add the column to the column superset #}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,42 +1,52 @@
-{% macro union_tables(tables, column_override=none, exclude=none, source_column_name=none) -%}
+{% macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name=none) -%}
+
+    {%- if exclude and include -%}
+        {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
+    {%- endif -%}
 
     {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
         {{ return('') }}
     {% endif %}
 
-    {%- set exclude = exclude if exclude is not none else [] %}
     {%- set column_override = column_override if column_override is not none else {} %}
-    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_table' %}
+    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_relation' %}
 
     {%- set table_columns = {} %}
     {%- set column_superset = {} %}
 
     {%- for table in tables -%}
 
-        {%- set _ = table_columns.update({table: []}) %}
+        {%- do table_columns.update({table: []}) %}
 
         {%- do dbt_utils._is_relation(table, 'union_tables') -%}
         {%- set cols = adapter.get_columns_in_relation(table) %}
         {%- for col in cols -%}
 
-        {%- if col.column not in exclude %}
+        {#- If an exclude list was provided and the column is in the list, do nothing #}
+        {%- if exclude and col.column in exclude %}
+
+        {#- If an include list was procided and the column is not in the list, do nothing -#}
+        {%- elif include and col.column not in include %}
+
+        {#- Otherwise add the column to the column superset #}
+        {% else %}
 
             {# update the list of columns in this table #}
-            {%- set _ = table_columns[table].append(col.column) %}
+            {%- do table_columns[table].append(col.column) %}
 
             {%- if col.column in column_superset -%}
 
                 {%- set stored = column_superset[col.column] %}
                 {%- if col.is_string() and stored.is_string() and col.string_size() > stored.string_size() -%}
 
-                    {%- set _ = column_superset.update({col.column: col}) %}
+                    {%- do column_superset.update({col.column: col}) %}
 
                 {%- endif %}
 
             {%- else -%}
 
-                {%- set _ =  column_superset.update({col.column: col}) %}
+                {%- do column_superset.update({col.column: col}) %}
 
             {%- endif -%}
 


### PR DESCRIPTION
Started off by adding an `include` parameter to `union`. But then when I was updating the docs I decided that having this macro named `union_tables` is silly so did some work to tidy that up. And then I did the same for `get_tables_by_prefix` and `unpivot`. Pretty happy with this pattern!

(This is probably the way we should have done this when we upgraded to 0.14.0, but ah well! This provides us a path to deprecate some macros though!)

I also tidied up some docs along the way.

#### Deprecating the `get_tables_by_prefix` and `union_tables` macros:
Here's what happens when you use the old macros:
```
$ dbt run -m test_get_tables_by_prefix_and_union
Running with dbt=0.15.0
Found 35 models, 53 tests, 0 snapshots, 0 analyses, 260 macros, 0 operations, 43 seed files, 0 sources

14:22:57 | Concurrency: 1 threads (target='redshift')
14:22:57 |
14:22:57 | 1 of 1 START table model integration_tests_dev.test_get_tables_by_prefix_and_union [RUN]
Warning: the `get_tables_by_prefix` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `get_relations_by_prefix` macro instead
Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `union_relations` macro instead
14:22:58 | 1 of 1 OK created table model integration_tests_dev.test_get_tables_by_prefix_and_union [SELECT in 1.20s]
14:22:59 |
14:22:59 | Finished running 1 table model in 2.81s.

Completed successfully

Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
These warnings _don't_ show up when you use the `relation` versions of these macros:
> Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `union_relations` macro instead

#### Replacing the `table` arg with `relation` in `unpivot`:
This one was a little tricker to implement, but it works! LMK if you want me to go through this.

