### PR TITLE
Remove redundant SELECT

### DIFF
--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -50,12 +50,12 @@ unioned as (
 
 final as (
 
-    select (select count(*) from unioned) +
-        (select abs(
+    select (
+      select count(*) from unioned) +
+        abs(
             (select count(*) from a_minus_b) -
             (select count(*) from b_minus_a)
-            ))
-        as count
+      ) as count
 
 )
 


### PR DESCRIPTION
Spark does not like the additional `SELECT` in front of the `abs(..)`. Therefore I'd suggest removing it, if that is ok with the other database engines.