### PR TITLE
Reduce whitespace in union macro

### DIFF
--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -1,8 +1,8 @@
 {# string  -------------------------------------------------     #}
 
-{% macro type_string() %}
+{%- macro type_string() -%}
   {{ adapter_macro('dbt_utils.type_string') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_string() %}
     string
@@ -24,9 +24,9 @@
 
 {# timestamp  -------------------------------------------------     #}
 
-{% macro type_timestamp() %}
+{%- macro type_timestamp() -%}
   {{ adapter_macro('dbt_utils.type_timestamp') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_timestamp() %}
     timestamp
@@ -39,9 +39,9 @@
 
 {# float  -------------------------------------------------     #}
 
-{% macro type_float() %}
+{%- macro type_float() -%}
   {{ adapter_macro('dbt_utils.type_float') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_float() %}
     float
@@ -53,9 +53,9 @@
 
 {# numeric  ------------------------------------------------     #}
 
-{% macro type_numeric() %}
+{%- macro type_numeric() -%}
   {{ adapter_macro('dbt_utils.type_numeric') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_numeric() %}
     numeric(28, 6)
@@ -68,9 +68,9 @@
 
 {# bigint  -------------------------------------------------     #}
 
-{% macro type_bigint() %}
+{%- macro type_bigint() -%}
   {{ adapter_macro('dbt_utils.type_bigint') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_bigint() %}
     bigint
@@ -82,9 +82,9 @@
 
 {# int  -------------------------------------------------     #}
 
-{% macro type_int() %}
+{%- macro type_int() -%}
   {{ adapter_macro('dbt_utils.type_int') }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__type_int() %}
     int

--- a/macros/cross_db_utils/literal.sql
+++ b/macros/cross_db_utils/literal.sql
@@ -1,7 +1,7 @@
 
-{% macro string_literal(value) %}
+{%- macro string_literal(value) -%}
   {{ adapter_macro('dbt_utils.string_literal', value) }}
-{% endmacro %}
+{%- endmacro -%}
 
 {% macro default__string_literal(value) -%}
     '{{ value }}'

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,92 +1,94 @@
-{% macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name=none) -%}
+{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name=none) -%}
 
     {%- if exclude and include -%}
         {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
     {%- endif -%}
 
-    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
-    {%- if not execute -%}
+    {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. -#}
+    {%- if not execute %}
         {{ return('') }}
-    {% endif %}
+    {% endif -%}
 
-    {%- set column_override = column_override if column_override is not none else {} %}
-    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_relation' %}
+    {%- set column_override = column_override if column_override is not none else {} -%}
+    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_relation' -%}
 
-    {%- set relation_columns = {} %}
-    {%- set column_superset = {} %}
+    {%- set relation_columns = {} -%}
+    {%- set column_superset = {} -%}
 
     {%- for relation in relations -%}
 
-        {%- do relation_columns.update({relation: []}) %}
+        {%- do relation_columns.update({relation: []}) -%}
 
         {%- do dbt_utils._is_relation(relation, 'union_relations') -%}
-        {%- set cols = adapter.get_columns_in_relation(relation) %}
+        {%- set cols = adapter.get_columns_in_relation(relation) -%}
         {%- for col in cols -%}
 
-        {#- If an exclude list was provided and the column is in the list, do nothing #}
-        {%- if exclude and col.column in exclude %}
+        {#- If an exclude list was provided and the column is in the list, do nothing -#}
+        {%- if exclude and col.column in exclude -%}
 
         {#- If an include list was provided and the column is not in the list, do nothing -#}
-        {%- elif include and col.column not in include %}
+        {%- elif include and col.column not in include -%}
 
-        {#- Otherwise add the column to the column superset #}
-        {% else %}
+        {#- Otherwise add the column to the column superset -#}
+        {%- else -%}
 
-            {# update the list of columns in this relation #}
-            {%- do relation_columns[relation].append(col.column) %}
+            {#- update the list of columns in this relation -#}
+            {%- do relation_columns[relation].append(col.column) -%}
 
             {%- if col.column in column_superset -%}
 
-                {%- set stored = column_superset[col.column] %}
+                {%- set stored = column_superset[col.column] -%}
                 {%- if col.is_string() and stored.is_string() and col.string_size() > stored.string_size() -%}
 
-                    {%- do column_superset.update({col.column: col}) %}
+                    {%- do column_superset.update({col.column: col}) -%}
 
                 {%- endif %}
 
             {%- else -%}
 
-                {%- do column_superset.update({col.column: col}) %}
+                {%- do column_superset.update({col.column: col}) -%}
 
             {%- endif -%}
 
         {%- endif -%}
 
-        {%- endfor %}
-    {%- endfor %}
+        {%- endfor -%}
+    {%- endfor -%}
 
-    {%- set ordered_column_names = column_superset.keys() %}
+    {%- set ordered_column_names = column_superset.keys() -%}
 
-    {%- for relation in relations -%}
+    {%- for relation in relations %}
 
         (
             select
 
                 cast({{ dbt_utils.string_literal(relation) }} as {{ dbt_utils.type_string() }}) as {{ source_column_name }},
-
                 {% for col_name in ordered_column_names -%}
 
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
                     {%- set col_name = adapter.quote(col_name) if col_name in relation_columns[relation] else 'null' %}
-                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif %}
+                    cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
+
                 {%- endfor %}
 
             from {{ relation }}
         )
 
-        {% if not loop.last %} union all {% endif %}
+        {% if not loop.last -%}
+            union all
+        {% endif -%}
 
-    {%- endfor %}
+    {%- endfor -%}
 
-{%- endmacro %}
+{%- endmacro -%}
 
-{% macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_table') -%}
+{%- macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_table') -%}
 
-    {% if execute %}
+    {%- if execute -%}
         {{ log("Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `union_relations` macro instead", info=True) }}
-    {% endif %}
+    {%- endif -%}
 
     {{ return(dbt_utils.union_relations(tables, column_override, include, exclude, source_column_name)) }}
 
-{% endmacro %}
+{%- endmacro -%}


### PR DESCRIPTION
This dramatically reduces whitespace when unioning a large number of tables.

Currently the whitespace is largely created by the initial looping to resolve relations and columns. This results in thousands of lines of whitespace in our current workflow - we believe this is actually resulting in a hard-limit on querying redshift in some workflows due to the query length as we get an ambiguous redshift error when adding columns.

Test before:

```sql


            

            

            

            

            

            (
            select

                cast(
  '"analytics"."analyst_charlie_briggs_scratch"."data_union_table_1"'
 as 
  varchar
) as _dbt_source_relation,

                
                    cast("id" as integer) as "id" ,
                    cast("name" as character varying(5)) as "name" ,
                    cast("favorite_number" as character varying(2)) as "favorite_number" ,
                    cast(null as character varying(5)) as "favorite_color" 

            from "analytics"."analyst_charlie_briggs_scratch"."data_union_table_1"
        )

         union all (
            select

                cast(
  '"analytics"."analyst_charlie_briggs_scratch"."data_union_table_2"'
 as 
  varchar
) as _dbt_source_relation,

                
                    cast("id" as integer) as "id" ,
                    cast(null as character varying(5)) as "name" ,
                    cast("favorite_number" as character varying(2)) as "favorite_number" ,
                    cast("favorite_color" as character varying(5)) as "favorite_color" 

            from "analytics"."analyst_charlie_briggs_scratch"."data_union_table_2"
        )

        
```

Test after:

```sql


        (
            select

                cast('"analytics"."analyst_charlie_briggs_scratch"."data_union_table_1"' as varchar) as _dbt_source_relation,
                
                    cast("id" as integer) as "id" ,
                    cast("name" as character varying(5)) as "name" ,
                    cast("favorite_number" as character varying(2)) as "favorite_number" ,
                    cast(null as character varying(5)) as "favorite_color" 

            from "analytics"."analyst_charlie_briggs_scratch"."data_union_table_1"
        )

        union all

    

        (
            select

                cast('"analytics"."analyst_charlie_briggs_scratch"."data_union_table_2"' as varchar) as _dbt_source_relation,
                
                    cast("id" as integer) as "id" ,
                    cast(null as character varying(5)) as "name" ,
                    cast("favorite_number" as character varying(2)) as "favorite_number" ,
                    cast("favorite_color" as character varying(5)) as "favorite_color" 

            from "analytics"."analyst_charlie_briggs_scratch"."data_union_table_2"
        )

        

```

There's still a little room for improvement in the readability of the output and further reducing blank lines but any further changes would begin to impact the readability of the macro code.