### PR TITLE
Clean up star macro

### DIFF
--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -12,7 +12,7 @@
     {%- for col in cols -%}
 
         {%- if col.column not in except -%}
-            {% set _ = include_cols.append(col.column) %}
+            {% do include_cols.append(col.column) %}
 
         {%- endif %}
     {%- endfor %}

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -19,8 +19,8 @@
 
     {%- for col in include_cols %}
 
-        {%- if relation_alias %}{{ relation_alias }}.{% else %}{% endif %}{{ dbt_utils.identifier(col)|trim }}
-        {%- if not loop.last %},{{ '\n' }}{% endif %}
+        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ dbt_utils.identifier(col)|trim }}
+        {%- if not loop.last %},{{ '\n  ' }}{% endif %}
 
     {%- endfor -%}
 {%- endmacro %}


### PR DESCRIPTION
One thing I extremely hate is the compiled output of the star macro, which looks extra ugly in dbt Docs 😢.

This PR gets rid of a bunch of unnecessary whitespace. 

Before:
```
select

  "EVENT_TIME"
 ,


  "PAGE_URL"
 ,


  "GROUP"
 ,


  "CATEGORY"
 ,


  "BENCHMARK_INDEX"
 ,


  "SCORE"
 ,


  "INCLUDED_THINGS"
 from dev.model.some_table
```

After:
```
select
  "EVENT_TIME",
  "PAGE_URL",
  "GROUP",
  "CATEGORY",
  "BENCHMARK_INDEX",
  "SCORE",
  "INCLUDED_THINGS"
from dev.model.some_table
```