### PR TITLE
Whitespace cleanup: concat/current_timestamp/date_trunc/surrogate_key

### DIFF
--- a/macros/cross_db_utils/concat.sql
+++ b/macros/cross_db_utils/concat.sql
@@ -1,6 +1,6 @@
-{% macro concat(fields) %}
+{% macro concat(fields) -%}
   {{ adapter_macro('dbt_utils.concat', fields) }}
-{% endmacro %}
+{%- endmacro %}
 
 
 {% macro default__concat(fields) -%}

--- a/macros/cross_db_utils/current_timestamp.sql
+++ b/macros/cross_db_utils/current_timestamp.sql
@@ -1,6 +1,6 @@
-{% macro current_timestamp() %}
+{% macro current_timestamp() -%}
   {{ adapter_macro('dbt_utils.current_timestamp') }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__current_timestamp() %}
     current_timestamp::{{dbt_utils.type_timestamp()}}
@@ -16,9 +16,9 @@
 
 
 
-{% macro current_timestamp_in_utc() %}
+{% macro current_timestamp_in_utc() -%}
   {{ adapter_macro('dbt_utils.current_timestamp_in_utc') }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__current_timestamp_in_utc() %}
     {{dbt_utils.current_timestamp()}}

--- a/macros/cross_db_utils/date_trunc.sql
+++ b/macros/cross_db_utils/date_trunc.sql
@@ -1,6 +1,6 @@
-{% macro date_trunc(datepart, date) %}
+{% macro date_trunc(datepart, date) -%}
   {{ adapter_macro('dbt_utils.date_trunc', datepart, date) }}
-{% endmacro %}
+{%- endmacro %}
 
 {% macro default__date_trunc(datepart, date) %}
     date_trunc('{{datepart}}', {{date}})
@@ -8,9 +8,8 @@
 
 {% macro bigquery__date_trunc(datepart, date) %}
     timestamp_trunc(
-        cast({{date}} as timestamp), 
+        cast({{date}} as timestamp),
         {{datepart}}
     )
-    
 
 {% endmacro %}

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -1,16 +1,16 @@
 {%- macro surrogate_key() -%}
 
-{% set fields = [] %}
+{%- set fields = [] -%}
 
 {%- for field in varargs -%}
 
-    {% set _ = fields.append(
+    {%- set _ = fields.append(
         "coalesce(cast(" ~ field ~ " as " ~ dbt_utils.type_string() ~ "), '')"
-    ) %}
+    ) -%}
 
-    {% if not loop.last %}
-        {% set _ = fields.append("'-'") %}
-    {% endif %}
+    {%- if not loop.last %}
+        {%- set _ = fields.append("'-'") -%}
+    {%- endif -%}
 
 {%- endfor -%}
 


### PR DESCRIPTION
Minor change to remove extraneous whitespace from concat/current_timestamp/date_trunc/surrogate_key macros.

Mainly actioned to reduce the vertical space taken up by surrogate_key, which we use almost everywhere, in the DBT compiled docs view.

Surrogate key test before:

```sql
select
    

    
        
    

    
        
    

    md5(cast(
  concat(coalesce(cast(field_1 as 
    varchar
), ''), '-', coalesce(cast(field_2 as 
    varchar
), ''), '-', coalesce(cast(field_3 as 
    varchar
), ''))
 as 
    varchar
)) as actual,
    expected
```

Surrogate key test after:

```sql
select
    md5(cast(concat(coalesce(cast(field_1 as 
    varchar
), ''), '-', coalesce(cast(field_2 as 
    varchar
), ''), '-', coalesce(cast(field_3 as 
    varchar
), '')) as 
    varchar
)) as actual,
    expected
```

This could still be much improved (not newlining types) but I'm unsure if that would break some scenarios in any SQL dialect supported by this package.