### PR TITLE
Allow list input for surrogate key macro 

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Implements a cross-database way to generate a hashed surrogate key using the fie
 
 Usage:
 ```
-{{ dbt_utils.surrogate_key('field_a', 'field_b'[,...]) }}
+{{ dbt_utils.surrogate_key(['field_a', 'field_b'[,...]]) }}
 ```
 
 #### safe_add ([source](macros/sql/safe_add.sql))

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -104,7 +104,10 @@ models:
   - name: test_surrogate_key
     tests:
       - assert_equal:
-          actual: actual
+          actual: actual_arguments
+          expected: expected
+      - assert_equal:
+          actual: actual_list
           expected: expected
 
   - name: test_union

--- a/integration_tests/models/sql/test_surrogate_key.sql
+++ b/integration_tests/models/sql/test_surrogate_key.sql
@@ -6,7 +6,8 @@ with data as (
 )
 
 select
-    {{ dbt_utils.surrogate_key('field_1', 'field_2', 'field_3') }} as actual,
+    {{ dbt_utils.surrogate_key('field_1', 'field_2', 'field_3') }} as actual_arguments,
+    {{ dbt_utils.surrogate_key(['field_1', 'field_2', 'field_3']) }} as actual_list,
     expected
 
 from data

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -3,7 +3,7 @@
 
 {%- if varargs|length >= 1 %}
 
-{{ exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Multiple string arguments are longer supported and will be deprecated in a future release of dbt-utils.") }}
+{%- do exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Multiple string arguments are longer supported and will be deprecated in a future release of dbt-utils.") -%}
 
 {# first argument is not included in varargs, so add first element to field_list_xf #}
 {%- set field_list_xf = [field_list] -%}

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -1,8 +1,28 @@
-{%- macro surrogate_key() -%}
+{%- macro surrogate_key(field_list) -%}
 
-{% set fields = [] %}
 
-{%- for field in varargs -%}
+{%- if varargs|length >= 1 %}
+
+{{ log("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Multiple string arguments are longer supported and will be deprecated in a future release of dbt-utils.", info=True) }}
+
+{# first argument is not included in varargs, so add first element to field_list_xf #}
+{%- set field_list_xf = [field_list] -%}
+
+{%- for field in varargs %}
+{%- set _ = field_list_xf.append(field) -%}
+{%- endfor -%}
+
+{%- else -%}
+
+{# if using list, just set field_list_xf as field_list #}
+{%- set field_list_xf = field_list -%}
+
+{%- endif -%}
+
+
+{%- set fields = [] -%}
+
+{%- for field in field_list_xf -%}
 
     {% set _ = fields.append(
         "coalesce(cast(" ~ field ~ " as " ~ dbt_utils.type_string() ~ "), '')"

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -3,7 +3,7 @@
 
 {%- if varargs|length >= 1 %}
 
-{{ log("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Multiple string arguments are longer supported and will be deprecated in a future release of dbt-utils.", info=True) }}
+{{ exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Multiple string arguments are longer supported and will be deprecated in a future release of dbt-utils.") }}
 
 {# first argument is not included in varargs, so add first element to field_list_xf #}
 {%- set field_list_xf = [field_list] -%}


### PR DESCRIPTION
Per [this conversation](https://getdbt.slack.com/archives/C2JRRQDTL/p1584050118056100) in dbt Slack, I wanted to explore the idea of allowing the surrogate key macro to support lists, instead of the varargs method.

This PR:
* Adds a deprecation warning if the varargs method is used.
* Allows for a single list argument to the surrogate macro. 
* Updates the surrogate key tests.