### PR TITLE
Return target relation in insert by period materialization

### DIFF
--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -169,4 +169,7 @@
     -- no-op
   {%- endcall %}
 
+  -- Return the relations created in this materialization
+  {{ return({'relations': [target_relation]}) }}  
+
 {%- endmaterialization %}


### PR DESCRIPTION
```
* Deprecation Warning: The materialization ("insert_by_period") did not
explicitly return a list of relations to add to the cache. By default the target
relation will be added, but this behavior will be removed in a future version of
dbt.
For more information, see:
https://docs.getdbt.com/v0.15/docs/creating-new-
materializations#section-6-returning-relations
```
