### PR TITLE
Add unique_where and not_null_where schema tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,30 @@ models:
 
 ```
 
+#### unique_where ([source](macros/schema_tests/unique_where.sql))
+This test validates that there are no duplicate values present in a field for a subset of rows by specifying a `where` clause.
+
+Usage:
+```yaml
+    columns:
+        - name: id
+          tests:
+            - unique_where:
+                where: "_deleted = false"
+```
+
+#### not_null_where ([source](macros/schema_tests/not_null_where.sql))
+This test validates that there are no null values present in a column for a subset of rows by specifying a `where` clause.
+
+Usage:
+```yaml
+    columns:
+        - name: id
+          tests:
+            - not_null_where:
+                where: "_deleted = false"
+```
+
 #### relationships_where ([source](macros/schema_tests/relationships_where.sql))
 This test validates the referential integrity between two relations (same as the core relationships schema test) with an added predicate to filter out some rows from the test. This is useful to exclude records such as test entities, rows created in the last X minutes/hours to account for temporary gaps due to ETL limitations, etc.
 

--- a/integration_tests/data/schema_tests/data_test_not_null_where.csv
+++ b/integration_tests/data/schema_tests/data_test_not_null_where.csv
@@ -1,0 +1,5 @@
+id,_deleted
+1,false
+2,false
+ ,true
+3,false

--- a/integration_tests/data/schema_tests/data_test_unique_where.csv
+++ b/integration_tests/data/schema_tests/data_test_unique_where.csv
@@ -1,0 +1,5 @@
+id,_deleted
+1,false
+2,false
+2,true
+3,true

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -50,6 +50,20 @@ models:
               field: is_active
               to: ref('data_people')
 
+  - name: data_test_unique_where
+    columns:
+      - name: id
+        tests:
+          - not_null_where:
+              where: "_deleted = false"
+
+  - name: data_test_not_null_where
+    columns:
+      - name: id
+        tests:
+          - not_null_where:
+              where: "_deleted = false"
+
   - name: data_test_relationships_where_table_2
     columns:
       - name: id

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -54,7 +54,7 @@ models:
     columns:
       - name: id
         tests:
-          - not_null_where:
+          - unique_where:
               where: "_deleted = false"
 
   - name: data_test_not_null_where

--- a/macros/schema_tests/test_not_null_where.sql
+++ b/macros/schema_tests/test_not_null_where.sql
@@ -1,0 +1,11 @@
+{% macro test_not_null_where(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set where = kwargs.get('where', kwargs.get('arg')) %}
+
+select count(*)
+from {{ model }}
+where {{ column_name }} is null
+{% if where %} and {{ where }} {% endif %}
+
+{% endmacro %}

--- a/macros/schema_tests/test_unique_where.sql
+++ b/macros/schema_tests/test_unique_where.sql
@@ -1,0 +1,20 @@
+{% macro test_unique_where(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set where = kwargs.get('where', kwargs.get('arg')) %}
+
+select count(*)
+from (
+
+    select
+        {{ column_name }}
+
+    from {{ model }}
+    where {{ column_name }} is not null
+      {% if where %} and {{ where }} {% endif %}
+    group by {{ column_name }}
+    having count(*) > 1
+
+) validation_errors
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
Add `not_null_where` and `unique_where` schema tests.

These slightly modified schema tests from core enables analysts to run these tests on a subset of records. These are useful to run tests on sources that may contain soft-deleted records, or to exclude known errors that cannot be fixed.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
