### PR TITLE
Add accepted values from source schema test

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ models:
 
 ```
 
+#### accepted_values_from([source](macros/schema_tests/accepted_values_from.sql))
+Much like the built in accepted_values test this test asserts that all values of a given column are
+in a list. However the list comes from a source or relationship.  
+
+Usage:
+```yaml
+- name: test_accepted_values_from_with_rename
+    columns:
+      - name: destination_column
+        tests:
+          - dbt_utils.accepted_values_from:
+              relationship: ref('data_test_accepted_values_from_source')
+              field: lookup
+  - name: test_accepted_values_from_without_rename
+    columns:
+        - name: lookup
+          tests:
+            - dbt_utils.accepted_values_from:
+                relationship: ref('data_test_accepted_values_from_source')
+```
+
 #### equality ([source](macros/schema_tests/equality.sql))
 This schema test asserts the equality of two relations. Optionally specify a subset of columns to compare.
 

--- a/integration_tests/data/schema_tests/data_test_accepted_values_from_source.csv
+++ b/integration_tests/data/schema_tests/data_test_accepted_values_from_source.csv
@@ -1,0 +1,5 @@
+id,lookup
+1,val1
+2,val2
+3,val3
+4,val2

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -87,3 +87,17 @@ models:
           combination_of_columns:
             - month
             - product
+            -
+  - name: test_accepted_values_from_with_rename
+    columns:
+      - name: destination_column
+        tests:
+          - dbt_utils.accepted_values_from:
+              relationship: ref('data_test_accepted_values_from_source')
+              field: lookup
+  - name: test_accepted_values_from_without_rename
+    columns:
+        - name: lookup
+          tests:
+            - dbt_utils.accepted_values_from:
+                relationship: ref('data_test_accepted_values_from_source')

--- a/integration_tests/models/schema_tests/test_accepted_values_from_with_rename.sql
+++ b/integration_tests/models/schema_tests/test_accepted_values_from_with_rename.sql
@@ -1,0 +1,8 @@
+with source as (
+    select * from {{ ref('data_test_accepted_values_from_source') }}
+), renamed as(
+    select id,
+           lookup as destination_column
+    from source
+)
+select * from renamed

--- a/integration_tests/models/schema_tests/test_accepted_values_from_without_rename.sql
+++ b/integration_tests/models/schema_tests/test_accepted_values_from_without_rename.sql
@@ -1,0 +1,8 @@
+with source as (
+    select * from {{ ref('data_test_accepted_values_from_source') }}
+), not_renamed as(
+    select id,
+           lookup
+    from source
+)
+select * from not_renamed

--- a/macros/schema_tests/accepted_values_from.sql
+++ b/macros/schema_tests/accepted_values_from.sql
@@ -1,0 +1,28 @@
+{% macro test_accepted_values_from(model) %}
+    {% set column_name = kwargs.get('column_name') %}
+    {% set from_relationship = kwargs.get('relationship') %}
+    {% set referenced_column = kwargs.get('field', column_name) %}
+    {% set filter = kwargs.get('filter', 'true') %}
+    with accepted_values as (
+        select
+            distinct( {{ referenced_column }}) as accepted
+        from
+            {{ from_relationship }}
+        where
+            {{ filter }}
+    ), validation_failures as (
+        select
+            {{ column_name }}
+        from
+            {{ model }}
+        where
+            {{ column_name }} not in (select accepted from accepted_values)
+    )
+    select
+           count(*)
+    from
+         validation_failures
+
+
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
I found myself doing a `SELECT DISTINCT(blah) FROM BOOM` and using that to add an `accepted_values` test. For obvious reasons, that's suboptimal, so I threw together this schema test.
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
