### PR TITLE
Update config-version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,8 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: ">=0.15.1"
+require-dbt-version: ">=0.17.0"
+config-version: 2
 
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]


### PR DESCRIPTION
resolves #229 

## Description & motivation

I wanted to remove the `config-version` deprecation errors for users using the recently released 0.17.0 version of dbt. This PR adds that config version to the project file and also bumps the required dbt version.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
