### PR TITLE
set config-version: 2

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,8 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: ">=0.15.1"
+require-dbt-version: ">=0.17.0"
+config-version: 2
 
 target-path: "target"
 clean-targets: ["target", "dbt_modules"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -4,7 +4,9 @@ version: '1.0'
 
 profile: 'integration_tests'
 
-require-dbt-version: ">=0.15.1"
+# require-dbt-version: inherit this from dbt-utils
+
+config-version: 2
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]
@@ -19,30 +21,28 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 seeds:
 
-  quote_columns: false
+  +quote_columns: false
   dbt_utils_integration_tests:
-    enabled: true
 
     cross_db:
       data_date_trunc:
-        column_types:
+        +column_types:
           updated_at: timestamp
           day: date
           month: date
 
       data_dateadd:
-        column_types:
+        +column_types:
           from_time: timestamp
           result: timestamp
 
       data_datediff:
-        column_types:
+        +column_types:
           first_date: timestamp
           second_date: timestamp
 
-
       data_width_bucket:
-          column_types:
-            num_buckets: integer
-            min_value: float
-            max_value: float
+        +column_types:
+          num_buckets: integer
+          min_value: float
+          max_value: float


### PR DESCRIPTION
_[ Copied from #228 ]_

resolves #229 

## Description & motivation

I wanted to remove the `config-version` deprecation errors for users using the recently released 0.17.0 version of dbt. This PR adds that config version to the project file and also bumps the required dbt version.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
