### PR TITLE
Allow aliasing individual columns from star macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## Features
 * Add new `accepted_range` test ([#276](https://github.com/fishtown-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))
-* Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/fishtown-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313]) 
+* Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/fishtown-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313])
+* Allow individual columns in star macro to be aliased (code originally in [#230](https://github.com/fishtown-analytics/dbt-utils/pull/230/) from [@elliottohara](https://github.com/elliottohara), merged via [#245]) 
 
 # dbt-utils v0.6.2
 

--- a/README.md
+++ b/README.md
@@ -587,11 +587,11 @@ Usage:
 
 #### star ([source](macros/sql/star.sql))
 This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias.
-
+It also has an optional arg that allows aliasing of individual columns.
 Usage:
 ```
 select
-{{ dbt_utils.star(from=ref('my_model'), except=["exclude_field_1", "exclude_field_2"]) }}
+{{ dbt_utils.star(from=ref('my_model'), except=["exclude_field_1", "exclude_field_2"], aliases={"field_x":"pretty_name", "field_y":"another_pretty_name"}) }}
 from {{ref('my_model')}}
 ```
 

--- a/integration_tests/data/sql/data_star_aliases_expected.csv
+++ b/integration_tests/data/sql/data_star_aliases_expected.csv
@@ -1,0 +1,4 @@
+field_1,field_2,aliased
+a,b,c
+d,e,f
+g,h,i

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -2,6 +2,7 @@
 name: 'dbt_utils_integration_tests'
 version: '1.0'
 
+
 profile: 'integration_tests'
 
 # require-dbt-version: inherit this from dbt-utils

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -101,6 +101,11 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
+  - name: test_star_aliases
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('data_star_aliases_expected')
+
   - name: test_surrogate_key
     tests:
       - assert_equal:

--- a/integration_tests/models/sql/test_star_aliases.sql
+++ b/integration_tests/models/sql/test_star_aliases.sql
@@ -1,0 +1,16 @@
+
+-- TODO : Should the star macro use a case-insensitive comparison for the `except` field on Snowflake?
+
+{% set aliases = {'FIELD_3':'aliased'} if target.type == 'snowflake' else {'field_3':'aliased'} %}
+
+
+with data as (
+
+    select
+        {{ dbt_utils.star(from=ref('data_star'), aliases=aliases) }}
+
+    from {{ ref('data_star') }}
+
+)
+
+select * from data

--- a/integration_tests/models/sql/test_star_aliases.sql
+++ b/integration_tests/models/sql/test_star_aliases.sql
@@ -1,7 +1,7 @@
 
 -- TODO : Should the star macro use a case-insensitive comparison for the `except` field on Snowflake?
 
-{% set aliases = {'FIELD_3':'aliased'} if target.type == 'snowflake' else {'field_3':'aliased'} %}
+{% set aliases = {'FIELD_3':'ALIASED'} if target.type == 'snowflake' else {'field_3':'aliased'} %}
 
 
 with data as (

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,4 +1,4 @@
-{% macro star(from, relation_alias=False, except=[]) -%}
+{% macro star(from, relation_alias=False, except=[], aliases={}) -%}
 
     {%- do dbt_utils._is_relation(from, 'star') -%}
     {%- do dbt_utils._is_ephemeral(from, 'star') -%}
@@ -21,7 +21,7 @@
 
     {%- for col in include_cols %}
 
-        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }}
+        {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}{{ adapter.quote(col)|trim }}{%- if col in aliases %} as {{ adapter.quote(aliases[col]) | trim }}{%- endif -%}
         {%- if not loop.last %},{{ '\n  ' }}{% endif %}
 
     {%- endfor -%}


### PR DESCRIPTION
From #230 (had to create a new PR so I could rebase the changes)

----

## Description & motivation
I love the `star` macro! I often find myself excluding columns just so I can alias them. This leads to less DRY code than I'd like, so I extended star to take an optional dictionary `{colname:aliasname}` and it will then alias the columns as expected. 
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
