### PR TITLE
Replace __TABLES_SUMMARY__ with INFORMATION_SCHEMA

### DIFF
--- a/macros/sql/get_tables_by_prefix_sql.sql
+++ b/macros/sql/get_tables_by_prefix_sql.sql
@@ -17,11 +17,11 @@
 {% macro bigquery__get_tables_by_prefix_sql(schema, prefix, exclude='', database=target.database) %}
     
         select distinct
-            dataset_id as table_schema, table_id as table_name
+            table_schema, table_name
 
-        from {{adapter.quote(database)}}.{{schema}}.__TABLES_SUMMARY__
-        where dataset_id = '{{schema}}'
-            and lower(table_id) like lower ('{{prefix}}%')
-            and lower(table_id) not like lower ('{{exclude}}')
+        from {{adapter.quote(database)}}.{{schema}}.INFORMATION_SCHEMA.TABLES
+        where table_schema = '{{schema}}'
+            and lower(table_name) like lower ('{{prefix}}%')
+            and lower(table_name) not like lower ('{{exclude}}')
 
 {% endmacro %}


### PR DESCRIPTION
Opening instead of #223 (had to rebase for tests)

From @preston-hf

## Description & motivation
INFORMATION_SCHEMA is actually [documented](https://cloud.google.com/bigquery/docs/information-schema-tables) and it requires less permissions than `__TABLES_SUMMARY__` which is not standardized and seems to require the ability to read the table, where INFORMATION_SCHEMA is queryable with just metadata access.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
