### PR TITLE
Add distinct argument to pivot macro. fka #213

### DIFF
--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -32,12 +32,12 @@ Arguments:
     alias: Whether to create column aliases, default is True
     agg: SQL aggregation function, default is sum
     cmp: SQL value comparison, default is =
-    dictinct: Whether to use distinct in the aggregation, default is False
     prefix: Column alias prefix, default is blank
     suffix: Column alias postfix, default is blank
     then_value: Value to use if comparison succeeds, default is 1
     else_value: Value to use if comparison fails, default is 0
     quote_identifiers: Whether to surround column aliases with double quotes, default is true
+    dictinct: Whether to use distinct in the aggregation, default is False
 #}
 
 {% macro pivot(column,
@@ -45,12 +45,12 @@ Arguments:
                alias=True,
                agg='sum',
                cmp='=',
-               distinct=False,
                prefix='',
                suffix='',
                then_value=1,
                else_value=0,
-               quote_identifiers=True) %}
+               quote_identifiers=True,
+               distinct=False) %}
   {% for v in values %}
     {{ agg }}(
       {% if distinct %} distinct {% endif %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -32,6 +32,7 @@ Arguments:
     alias: Whether to create column aliases, default is True
     agg: SQL aggregation function, default is sum
     cmp: SQL value comparison, default is =
+    dictinct: Whether to use distinct in the aggregation, default is False
     prefix: Column alias prefix, default is blank
     suffix: Column alias postfix, default is blank
     then_value: Value to use if comparison succeeds, default is 1
@@ -44,6 +45,7 @@ Arguments:
                alias=True,
                agg='sum',
                cmp='=',
+               distinct=False,
                prefix='',
                suffix='',
                then_value=1,
@@ -51,6 +53,7 @@ Arguments:
                quote_identifiers=True) %}
   {% for v in values %}
     {{ agg }}(
+      {% if distinct %} distinct {% endif %}
       case
       when {{ column }} {{ cmp }} '{{ v }}'
         then {{ then_value }}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -37,7 +37,7 @@ Arguments:
     then_value: Value to use if comparison succeeds, default is 1
     else_value: Value to use if comparison fails, default is 0
     quote_identifiers: Whether to surround column aliases with double quotes, default is true
-    dictinct: Whether to use distinct in the aggregation, default is False
+    distinct: Whether to use distinct in the aggregation, default is False
 #}
 
 {% macro pivot(column,


### PR DESCRIPTION
Opening in place of #213 as a rebase was needed to ensure the tests pass

From @DylanBaker 

> This PR adds a `distinct` argument to the pivot macro. When set to true, it adds `distinct` to the aggregate, immediately after the opening bracket.