### PR TITLE
Add unique_where and not_null_where schema tests. fka #219

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,30 @@ models:
 
 ```
 
+#### unique_where ([source](macros/schema_tests/unique_where.sql))
+This test validates that there are no duplicate values present in a field for a subset of rows by specifying a `where` clause.
+
+Usage:
+```yaml
+    columns:
+        - name: id
+          tests:
+            - unique_where:
+                where: "_deleted = false"
+```
+
+#### not_null_where ([source](macros/schema_tests/not_null_where.sql))
+This test validates that there are no null values present in a column for a subset of rows by specifying a `where` clause.
+
+Usage:
+```yaml
+    columns:
+        - name: id
+          tests:
+            - not_null_where:
+                where: "_deleted = false"
+```
+
 #### relationships_where ([source](macros/schema_tests/relationships_where.sql))
 This test validates the referential integrity between two relations (same as the core relationships schema test) with an added predicate to filter out some rows from the test. This is useful to exclude records such as test entities, rows created in the last X minutes/hours to account for temporary gaps due to ETL limitations, etc.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Check [dbt Hub](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/) for
 
 ## Macros
 ### Cross-database
-While these macros are cross database, they do not support all databases. 
-These macros are provided to make date calculations easier and are not a core part of dbt. 
-Most date macros are not supported on postgres. 
+While these macros are cross database, they do not support all databases.
+These macros are provided to make date calculations easier and are not a core part of dbt.
+Most date macros are not supported on postgres.
 
 #### current_timestamp ([source](macros/cross_db_utils/current_timestamp.sql))
 This macro returns the current timestamp.
@@ -254,11 +254,15 @@ This test validates that there are no duplicate values present in a field for a 
 
 Usage:
 ```yaml
+version: 2
+
+models:
+  - name: my_model
     columns:
-        - name: id
-          tests:
-            - unique_where:
-                where: "_deleted = false"
+      - name: id
+        tests:
+          - dbt_utils.unique_where:
+              where: "_deleted = false"
 ```
 
 #### not_null_where ([source](macros/schema_tests/not_null_where.sql))
@@ -266,11 +270,15 @@ This test validates that there are no null values present in a column for a subs
 
 Usage:
 ```yaml
+version: 2
+
+models:
+  - name: my_model
     columns:
-        - name: id
-          tests:
-            - not_null_where:
-                where: "_deleted = false"
+      - name: id
+        tests:
+          - dbt_utils.not_null_where:
+              where: "_deleted = false"
 ```
 
 #### relationships_where ([source](macros/schema_tests/relationships_where.sql))

--- a/integration_tests/data/schema_tests/data_test_not_null_where.csv
+++ b/integration_tests/data/schema_tests/data_test_not_null_where.csv
@@ -1,0 +1,5 @@
+id,_deleted
+1,false
+2,false
+ ,true
+3,false

--- a/integration_tests/data/schema_tests/data_test_unique_where.csv
+++ b/integration_tests/data/schema_tests/data_test_unique_where.csv
@@ -1,0 +1,5 @@
+id,_deleted
+1,false
+2,false
+2,true
+3,true

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -50,6 +50,20 @@ models:
               field: is_active
               to: ref('data_people')
 
+  - name: data_test_unique_where
+    columns:
+      - name: id
+        tests:
+          - not_null_where:
+              where: "_deleted = false"
+
+  - name: data_test_not_null_where
+    columns:
+      - name: id
+        tests:
+          - not_null_where:
+              where: "_deleted = false"
+
   - name: data_test_relationships_where_table_2
     columns:
       - name: id

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -54,14 +54,14 @@ models:
     columns:
       - name: id
         tests:
-          - unique_where:
+          - dbt_utils.unique_where:
               where: "_deleted = false"
 
   - name: data_test_not_null_where
     columns:
       - name: id
         tests:
-          - not_null_where:
+          - dbt_utils.not_null_where:
               where: "_deleted = false"
 
   - name: data_test_relationships_where_table_2

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -54,7 +54,7 @@ models:
     columns:
       - name: id
         tests:
-          - not_null_where:
+          - unique_where:
               where: "_deleted = false"
 
   - name: data_test_not_null_where

--- a/macros/schema_tests/test_not_null_where.sql
+++ b/macros/schema_tests/test_not_null_where.sql
@@ -1,0 +1,11 @@
+{% macro test_not_null_where(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set where = kwargs.get('where', kwargs.get('arg')) %}
+
+select count(*)
+from {{ model }}
+where {{ column_name }} is null
+{% if where %} and {{ where }} {% endif %}
+
+{% endmacro %}

--- a/macros/schema_tests/test_unique_where.sql
+++ b/macros/schema_tests/test_unique_where.sql
@@ -1,0 +1,20 @@
+{% macro test_unique_where(model) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set where = kwargs.get('where', kwargs.get('arg')) %}
+
+select count(*)
+from (
+
+    select
+        {{ column_name }}
+
+    from {{ model }}
+    where {{ column_name }} is not null
+      {% if where %} and {{ where }} {% endif %}
+    group by {{ column_name }}
+    having count(*) > 1
+
+) validation_errors
+
+{% endmacro %}


### PR DESCRIPTION
Opening in favor of #219, as I had to rebase to run the tests:

From @martinguindon

## Description & motivation
Add `not_null_where` and `unique_where` schema tests.

These slightly modified schema tests from core enables analysts to run these tests on a subset of records. These are useful to run tests on sources that may contain soft-deleted records, or to exclude known errors that cannot be fixed.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
