### PR TITLE
Allow for non-quote identifier column names in pivot even if values include non-alphanumeric symbols

### DIFF
--- a/macros/sql/cleanse_jinja.sql
+++ b/macros/sql/cleanse_jinja.sql
@@ -1,0 +1,11 @@
+{% macro cleanse_jinja(text) -%}
+{#
+Clean templated text outputs, so that it is compilable without quote identifiers
+
+Arguments:
+    text: text_to_clean
+#}
+
+        {{text.lower()|replace(" ", "_")|replace("/", "or")|replace("-", "to")|replace(">", "above")|replace("<", "below")|replace(",", "")|replace(".", "")|replace(",", "")|replace("=", "")|replace("(", "")|replace(")", "")|replace("'", "")|replace("!", "")|replace("@", "")|replace("$", "")|replace("%", "")|replace("&", "and")|replace("+", "plus") }}
+
+{%- endmacro %}

--- a/macros/sql/pivot.sql
+++ b/macros/sql/pivot.sql
@@ -61,10 +61,11 @@ Arguments:
       end
     )
     {% if alias %}
+      {% set column_name = prefix ~ v ~ suffix %}
       {% if quote_identifiers %}
-            as {{ adapter.quote(prefix ~ v ~ suffix) }}
+            as {{ adapter.quote(column_name) }}
       {% else %}
-        as {{prefix ~ v ~ suffix }}
+        as {{ cleanse_jinja(column_name) }}
       {% endif %}
     {% endif %}
     {% if not loop.last %},{% endif %}


### PR DESCRIPTION
## Description & motivation
<!---
dbt_utils.pivot will fail if:

1. quote_identifiers = False (who wants to have to quote every column...) AND 
2. the pivoted values have non-alphanumeric symbols (such as "+","-", " ")
-->

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
