### PR TITLE
change final->finale bc final keyword in exasol

### DIFF
--- a/macros/schema_tests/equal_rowcount.sql
+++ b/macros/schema_tests/equal_rowcount.sql
@@ -17,7 +17,7 @@ b as (
     select count(*) as count_b from {{ compare_model }}
 
 ),
-finale as (
+final_count as (
 
     select abs(
             (select count_a from a) -
@@ -27,6 +27,6 @@ finale as (
 
 )
 
-select diff_count from finale
+select diff_count from final_count
 
 {% endmacro %}

--- a/macros/schema_tests/equal_rowcount.sql
+++ b/macros/schema_tests/equal_rowcount.sql
@@ -17,7 +17,7 @@ b as (
     select count(*) as count_b from {{ compare_model }}
 
 ),
-final as (
+finale as (
 
     select abs(
             (select count_a from a) -
@@ -27,6 +27,6 @@ final as (
 
 )
 
-select diff_count from final
+select diff_count from finale
 
 {% endmacro %}

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -18,7 +18,7 @@ information schema — this allows the model to be an ephemeral model
 {%- endif -%}
 
 {% set compare_model = kwargs.get('compare_model', kwargs.get('arg')) %}
-{% set compare_columns = kwargs.get('compare_columns', adapter.get_columns_in_relation(model) | map(attribute='quoted') ) %}
+{% set compare_columns = kwargs.get('compare_columns', adapter.get_columns_in_relation(model) | map(attribute='name') ) %}
 {% set compare_cols_csv = compare_columns | join(', ') %}
 
 with a as (

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -57,7 +57,7 @@ unioned as (
 
 ),
 
-final as (
+finale as (
 
     select (select count(*) from unioned) +
         (select abs(
@@ -68,6 +68,6 @@ final as (
 
 )
 
-select count from final
+select count from finale
 
 {% endmacro %}

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -57,7 +57,7 @@ unioned as (
 
 ),
 
-finale as (
+final_count as (
 
     select (select count(*) from unioned) +
         (select abs(
@@ -68,6 +68,6 @@ finale as (
 
 )
 
-select count from finale
+select count from final_count
 
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
changed "final" -> "finale" in 2 macros to support dbt-exasol (github.com/tglunde/dbt-exasol) since "final" is a keywordin exasol.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
