### PR TITLE
Add package and model name in surrogate_key warning

### DIFF
--- a/macros/cross_db_utils/identifier.sql
+++ b/macros/cross_db_utils/identifier.sql
@@ -1,5 +1,9 @@
 {% macro identifier(value) %}	
-  {% do exceptions.warn("Warning: the `identifier` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use `adapter.quote` instead") %}
+  {%- set error_message = '
+    Warning: the `identifier` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
+    Use `adapter.quote` instead. The {}.{} model triggered this warning. \
+    '.format(model.package_name, model.name) -%}
+  {%- do exceptions.warn(error_message) -%}
   {{ adapter_macro('dbt_utils.identifier', value) }}	
 {% endmacro %}	
 

--- a/macros/sql/get_relations_by_prefix.sql
+++ b/macros/sql/get_relations_by_prefix.sql
@@ -23,8 +23,12 @@
 {% endmacro %}
 
 {% macro get_tables_by_prefix(schema, prefix, exclude='', database=target.database) %}
-
-    {% do exceptions.warn("Warning: the `get_tables_by_prefix` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `get_relations_by_prefix` macro instead") %}
+    {%- set error_message = '
+        Warning: the `get_tables_by_prefix` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
+        Use the `get_relations_by_prefix` macro instead. \
+        The {}.{} model triggered this warning. \
+        '.format(model.package_name, model.name) -%}
+    {%- do exceptions.warn(error_message) -%}
 
     {{ return(dbt_utils.get_relations_by_prefix(schema, prefix, exclude, database)) }}
 

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -2,7 +2,7 @@
 
 {%- if varargs|length >= 1 or field_list is string %}
 
-{%- do exceptions.warn("Warning: package:  the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The " ~ model.package_name ~ "." ~ model.name ~ " model triggered this warning.") -%}
+{%- do exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The " ~ model.package_name ~ "." ~ model.name ~ " model triggered this warning.") -%}
 
 {# first argument is not included in varargs, so add first element to field_list_xf #}
 {%- set field_list_xf = [field_list] -%}

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -2,7 +2,7 @@
 
 {%- if varargs|length >= 1 or field_list is string %}
 
-{%- do exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils.") -%}
+{%- do exceptions.warn("Warning: package:  the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The " ~ model.package_name ~ "." ~ model.name ~ " model triggered this warning.") -%}
 
 {# first argument is not included in varargs, so add first element to field_list_xf #}
 {%- set field_list_xf = [field_list] -%}

--- a/macros/sql/surrogate_key.sql
+++ b/macros/sql/surrogate_key.sql
@@ -2,7 +2,13 @@
 
 {%- if varargs|length >= 1 or field_list is string %}
 
-{%- do exceptions.warn("Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The " ~ model.package_name ~ "." ~ model.name ~ " model triggered this warning.") -%}
+{%- set error_message = '
+Warning: the `surrogate_key` macro now takes a single list argument instead of \
+multiple string arguments. Support for multiple string arguments will be \
+deprecated in a future release of dbt-utils. The {}.{} model triggered this warning. \
+'.format(model.package_name, model.name) -%}
+
+{%- do exceptions.warn(error_message) -%}
 
 {# first argument is not included in varargs, so add first element to field_list_xf #}
 {%- set field_list_xf = [field_list] -%}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -85,8 +85,12 @@
 {%- endmacro -%}
 
 {%- macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_table') -%}
-
-    {%- do exceptions.warn("Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. Use the `union_relations` macro instead") -%}
+    {%- set error_message = '
+        Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
+        Use the `union_relations` macro instead. \
+        The {}.{} model triggered this warning. \
+        '.format(model.package_name, model.name) -%}
+    {%- do exceptions.warn(error_message) -%}
 
     {{ return(dbt_utils.union_relations(tables, column_override, include, exclude, source_column_name)) }}
 

--- a/macros/sql/unpivot.sql
+++ b/macros/sql/unpivot.sql
@@ -15,7 +15,12 @@ Arguments:
 {% macro unpivot(relation=none, cast_to='varchar', exclude=none, remove=none, field_name='field_name', value_name='value', table=none) -%}
 
     {% if table %}
-        {% do exceptions.warn("Warning: the `unpivot` macro no longer accepts a `table` parameter. This parameter will be deprecated in a future release of dbt-utils. Use the `relation` parameter instead") %}
+        {%- set error_message = '
+            Warning: the `unpivot` macro no longer accepts a `table` parameter. \
+            This parameter will be deprecated in a future release of dbt-utils. Use the `relation` parameter instead. \
+            The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+        {%- do exceptions.warn(error_message) -%}
     {% endif %}
 
     {% if relation and table %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

This adds the package and model name to the surrogate key deprecation warning.

I tested by directly editing the macro in dbt modules after running deps. Produces:

> Running with dbt=0.17.1
Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The gitlab_snowflake.arr_changes_sfdc_account_monthly model triggered this warning.
Parsing on run start hooks...
Parsing on run end hooks...
Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The logging.stg_dbt_audit_log model triggered this warning.
Warning: the `surrogate_key` macro now takes a single list argument instead of multiple string arguments. Support for multiple string arguments will be deprecated in a future release of dbt-utils. The logging.stg_dbt_model_deployments model triggered this warning.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
