### PR TITLE
`no_time_gap` schema test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Fixes
 
 ## Features
+* Add `no_time_gap` schema test
 
 ## Quality of life
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,32 @@ case we recommend using this test instead.
           - product
 ```
 
+#### no_time_gap ([source](macros/schema_tests/no_time_gap.sql))
+This test asserts that a gap of the specified duration does not exist in a
+date or datetime column. For tables that are loaded incrementally, this test 
+can be used to verify that data loaded for all time intervals.
+
+**Usage:**
+```yaml
+version: 2
+
+models:
+  # tests that events exist in every 2 week interval in the past 52 weeks
+  - name: events
+    tests:
+      - dbt_utils.no_time_gap:
+          field: created_at
+          datepart: week
+          interval: 2
+          since: 52
+```
+**Args:**
+* `field` (required): The name of the column to test.
+* `datepart` (required): The date part to use as the unit for `interval` and `since`.
+* `interval` (required): The size of the gap that we are testing for. A gap of this 
+size or larger should not exist.
+* `since` (optional): If specified, the test only selects records created after since dateparts ago.
+
 ---
 ### SQL helpers
 #### get_query_results_as_dict ([source](macros/sql/get_query_results_as_dict.sql))

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -107,5 +107,5 @@ models:
       - dbt_utils.no_time_gap:
           datepart: day
           field: day
-          interval: 7
-          since: 100
+          interval: 2
+          since: 14

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -101,3 +101,11 @@ models:
           combination_of_columns:
             - month
             - product
+
+  - name: test_no_time_gap
+    tests:
+      - dbt_utils.no_time_gap:
+          datepart: day
+          field: day
+          interval: 7
+          since: 100

--- a/integration_tests/models/schema_tests/test_no_time_gap.sql
+++ b/integration_tests/models/schema_tests/test_no_time_gap.sql
@@ -1,0 +1,20 @@
+WITH RECURSIVE t(n) AS (
+    VALUES (0)
+  UNION ALL
+    SELECT n+1 FROM t WHERE n < 100
+)
+
+{% if target.type == 'postgres' %}
+
+select
+    {{ dbt_utils.date_trunc('day', dbt_utils.dateadd('day', '-1 * n', dbt_utils.current_timestamp())) }} as day
+
+{% else %}
+
+select
+    cast({{ dbt_utils.date_trunc('day', dbt_utils.dateadd('day', '-1 * n', dbt_utils.current_timestamp())) }} as datetime) as day
+
+{% endif %}
+
+from
+    t

--- a/integration_tests/models/schema_tests/test_no_time_gap.sql
+++ b/integration_tests/models/schema_tests/test_no_time_gap.sql
@@ -1,7 +1,10 @@
-WITH RECURSIVE t(n) AS (
-    VALUES (0)
-  UNION ALL
-    SELECT n+1 FROM t WHERE n < 100
+WITH sequence(n) AS (
+  select 0 union all select 1 union all select 2 union all
+  select 3 union all select 4 union all select 5 union all
+  select 6 union all select 7 union all select 8 union all
+  select 9 union all select 10 union all select 11 union all
+  select 12 union all select 13 union all select 14 union all
+  select 15 union all select 16 union all select 17
 )
 
 {% if target.type == 'postgres' %}
@@ -17,4 +20,4 @@ select
 {% endif %}
 
 from
-    t
+    sequence

--- a/macros/schema_tests/no_time_gap.sql
+++ b/macros/schema_tests/no_time_gap.sql
@@ -1,0 +1,29 @@
+{% macro test_no_time_gap(model, datepart, interval) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('field')) %}
+{% set since = kwargs.get('since', kwargs.get('since')) %}
+
+select
+    count(*) as error_result
+from {{model}} t1
+inner join {{model}} t2 on
+    t2.{{column_name}} = (
+        select
+            MAX(t3.{{column_name}})
+        from {{model}} t3
+        where
+            t3.{{column_name}} < t1.{{column_name}}
+        {% if since %}
+        and t3.{{column_name}} >=
+            {{dbt_utils.dateadd('year', -1, dbt_utils.current_timestamp())}}
+        {% endif %}
+    )
+where
+    {{dbt_utils.datediff('t2.' + column_name, 't1.' + column_name, datepart)}}
+    >= {{interval}}
+{% if since %}
+and t1.{{column_name}} >=
+    {{dbt_utils.dateadd('year', -1, dbt_utils.current_timestamp())}}
+{% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [x] new functionality
- [ ] a breaking change

## Description & motivation
Add `no_time_gap` schema test 

(Open to suggestions on the name 😉)

This test asserts that the largest gap between records is less than the specified interval. For example, if you have a source table that is loaded once per day, you can use this test to find any gaps larger than 1 day in the data.

Example/Usage:
```yaml
version: 2

models:
  # tests that events exist in every 2 day interval in the past year
  - name: events
    tests:
      - dbt_utils.no_time_gap:
          field: created_at
          datepart: day
          interval: 2
          since: 365
```

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to the changelog
