### PR TITLE
Remove some deprecated macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # dbt-utils v0.6.0 (unreleased)
 
+## Breaking changes
+- :rotating_light: dbt v0.18.0 or greater is required for this release. If you are not ready to upgrade, consider using a previous release of this package
+- :rotating_light: The `get_tables_by_prefix`, `union_tables` and `get_tables_by_pattern` macros have been removed
+
+## Migration instructions
+- Upgrade your dbt project to v0.18.0 using [these instructions](https://discourse.getdbt.com/t/prerelease-v0-18-0-marian-anderson/1545).
+- Upgrade your `dbt_project.yml` file to use version `0.7.0`. Run `dbt clean` and `dbt deps`.
+- If your project uses the `get_tables_by_prefix` macro, replace it with `get_relations_by_prefix`. All arguments have retained the same name.
+- If your project uses the `union_tables` macro, replace it with `union_relations`. While the order of arguments has stayed consistent, the `tables` argument has been renamed to `relations`. Further, the default value for the `source_column_name` argument has changed from `'_dbt_source_table'` to `'_dbt_source_relation'` — you may want to explicitly define this argument to avoid breaking changes.
+
+```
+-- before:
+{{ dbt_utils.union_tables(
+    tables=[ref('my_model'), source('my_source', 'my_table')],
+    exclude=["_loaded_at"]
+) }}
+
+-- after:
+{{ dbt_utils.union_relations(
+    relations=[ref('my_model'), source('my_source', 'my_table')],
+    exclude=["_loaded_at"],
+    source_column_name='_dbt_source_table'
+) }}
+```
+- If your project uses the `get_tables_by_pattern` macro, replace it with `get_tables_by_pattern_sql` — all arguments are consistent.
+
 ## Fixes
 
 ## Features
@@ -11,6 +37,8 @@ specific to their database (#267)
 database adapters that use different prefixes (#267)
 
 ## Quality of life
+* Remove deprecated macros `get_tables_by_prefix` and `union_tables` (#268)
+* Remove `get_tables_by_pattern` macro, which is equivalent to the `get_tables_by_pattern_sql` macro (the latter has a more logical name)
 
 # dbt-utils v0.5.1
 

--- a/README.md
+++ b/README.md
@@ -442,9 +442,6 @@ Usage:
 ...
 ```
 #### get_relations_by_prefix
-> This replaces the `get_tables_by_prefix` macro. Note that the `get_tables_by_prefix` macro will
-be deprecated in a future release of this package.
-
 Returns a list of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation)
 that match a given prefix, with an optional exclusion pattern. It's particularly
 handy paired with `union_relations`.
@@ -516,8 +513,6 @@ from {{ref('my_model')}}
 ```
 
 #### union_relations ([source](macros/sql/union.sql))
-> This replaces the `union_tables` macro. Note that the `union_tables` macro will
-be deprecated in a future release of this package.
 
 This macro unions together an array of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation),
 even when columns have differing orders in each Relation, and/or some columns are

--- a/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
+++ b/integration_tests/models/sql/test_get_tables_by_prefix_and_union.sql
@@ -1,4 +1,0 @@
-{{config( materialized = 'table')}}
-
-{% set tables = dbt_utils.get_tables_by_prefix(target.schema, 'data_events_') %}
-{{ dbt_utils.union_tables(tables) }}

--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -21,15 +21,3 @@
     {%- endif -%}
 
 {% endmacro %}
-
-{% macro get_tables_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
-    {%- set error_message = '
-        Warning: the `get_tables_by_pattern` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
-        Use the `get_relations_by_prefix` macro instead. \
-        The {}.{} model triggered this warning. \
-        '.format(model.package_name, model.name) -%}
-    {%- do exceptions.warn(error_message) -%}
-
-    {{ return(dbt_utils.get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database)) }}
-
-{% endmacro %} 

--- a/macros/sql/get_relations_by_prefix.sql
+++ b/macros/sql/get_relations_by_prefix.sql
@@ -21,15 +21,3 @@
     {%- endif -%}
 
 {% endmacro %}
-
-{% macro get_tables_by_prefix(schema, prefix, exclude='', database=target.database) %}
-    {%- set error_message = '
-        Warning: the `get_tables_by_prefix` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
-        Use the `get_relations_by_prefix` macro instead. \
-        The {}.{} model triggered this warning. \
-        '.format(model.package_name, model.name) -%}
-    {%- do exceptions.warn(error_message) -%}
-
-    {{ return(dbt_utils.get_relations_by_prefix(schema, prefix, exclude, database)) }}
-
-{% endmacro %}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -83,15 +83,3 @@
     {%- endfor -%}
 
 {%- endmacro -%}
-
-{%- macro union_tables(tables, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_table') -%}
-    {%- set error_message = '
-        Warning: the `union_tables` macro is no longer supported and will be deprecated in a future release of dbt-utils. \
-        Use the `union_relations` macro instead. \
-        The {}.{} model triggered this warning. \
-        '.format(model.package_name, model.name) -%}
-    {%- do exceptions.warn(error_message) -%}
-
-    {{ return(dbt_utils.union_relations(tables, column_override, include, exclude, source_column_name)) }}
-
-{%- endmacro -%}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -1,4 +1,4 @@
-{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name=none) -%}
+{%- macro union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation') -%}
 
     {%- if exclude and include -%}
         {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
@@ -10,7 +10,6 @@
     {% endif -%}
 
     {%- set column_override = column_override if column_override is not none else {} -%}
-    {%- set source_column_name = source_column_name if source_column_name is not none else '_dbt_source_relation' -%}
 
     {%- set relation_columns = {} -%}
     {%- set column_superset = {} -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [ ] new functionality
- [x] a breaking change

## To do before merge
- [x] Update base branch to `dev/0.6.0` once #267 is merged
- [x] Update the changelog

## Description & motivation
I removed `union_tables` and `get_tables_by_prefix`, which we deprecated >6 months ago as part of [v0.2.4](https://github.com/fishtown-analytics/dbt-utils/releases/tag/0.2.4) in Dec 2019

I also removed `get_tables_by_pattern` — this was introduced in v0.5.0 and is functionally equivalent to `get_tables_by_pattern_sql`. Given few people would be using this macro (as it's a helper macro), we are going to go straight to removing it rather than deprecating it first.

We could also consider deprecating:
- The old arguments for `surrogate_key` macro: deprecated in v0.3.0 /  April 2020
- `identifier`: deprecation warning added in  v0.4.0 / April 2020 (deprecated before then but not marked as such)

Personally, I think we should wait until the _next_ version of utils to deprecate those

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to the changelog
