### PR TITLE
Added quote_columns=(true | false) flag to the unique_combination_of_columns.sql macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@ database adapters that use different prefixes (#267)
 ## Quality of life
 * Improve release process, and fix tests (#251)
 * Make deprecation warnings more useful (#258 @tayloramurphy)
+* Upgrade unique_combination_of_columns.sql macro to respect the quote_columns=TRUE flag as a test argument

--- a/macros/schema_tests/unique_combination_of_columns.sql
+++ b/macros/schema_tests/unique_combination_of_columns.sql
@@ -1,8 +1,22 @@
-{% macro test_unique_combination_of_columns(model) %}
+{% macro test_unique_combination_of_columns(model, quote_columns = false) %}
 
 {%- set columns = kwargs.get('combination_of_columns', kwargs.get('arg')) %}
 
-{%- set columns_csv=columns | join(', ') %}
+{% if not quote_columns %}
+    {%- set column_list=columns %}
+{% elif quote_columns %}
+    {%- set column_list=[] %}
+        {% for column in columns -%}
+            {% set column_list = column_list.append( adapter.quote(column) ) %}
+        {%- endfor %}
+{% else %}
+    {{ exceptions.raise_compiler_error(
+        "`quote_columns` argument for unique_combination_of_columns test must be one of [True, False] Got: '" ~ quote ~"'.'"
+    ) }}
+{% endif %}
+
+{%- set columns_csv=column_list | join(', ') %}
+
 
 with validation_errors as (
 


### PR DESCRIPTION
…ng of columns.

This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [X] new functionality
- [ ] a breaking change

## Description & motivation
<!---
The original query does not respect the global quoted columns flag and was broken for column names that required quotes. This query resolves that issue.
-->

## Checklist
- [X] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [X] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have added an entry to the changelog
