### PR TITLE
Remove errant default args from get_tables_by_pattern_sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt-utils v0.6.2
+
+## Fixes
+- Fix the logic in `get_tables_by_pattern_sql` to ensure non-default arguments are respected ([#279](https://github.com/fishtown-analytics/dbt-utils/pull/279))
+
+
 # dbt-utils v0.6.1
 
 ## Fixes

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -1,6 +1,6 @@
 {% macro get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
     {{ adapter.dispatch('get_tables_by_pattern_sql', packages = dbt_utils._get_utils_namespaces())
-        (schema_pattern, table_pattern, exclude='', database=target.database) }}
+        (schema_pattern, table_pattern, exclude, database) }}
 {% endmacro %}
 
 {% macro default__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes (please change the base branch to `main`)
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
Turns out that this line forces the argument to be the default value.

Closes [this issue on codegen](https://github.com/fishtown-analytics/dbt-codegen/issues/33)

## Testing
I updated my local version of codegen to also use my local version of utils, and tested locally.

I also did a quick `cmf + f` to find any other instances of this, and couldn't see anything — would definitely appreciate a second set of eyes there

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to the changelog


