### PR TITLE
Make star macro case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Usage:
 ```
 
 #### star ([source](macros/sql/star.sql))
-This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument. The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias.
+This macro generates a list of all fields that exist in the `from` relation, excluding any fields listed in the `except` argument (case insensitive). The construction is identical to `select * from {{ref('my_model')}}`, replacing star (`*`) with the star macro. This macro also has an optional `relation_alias` argument that will prefix all generated fields with an alias.
 
 Usage:
 ```

--- a/integration_tests/models/sql/test_star.sql
+++ b/integration_tests/models/sql/test_star.sql
@@ -1,7 +1,5 @@
 
--- TODO : Should the star macro use a case-insensitive comparison for the `except` field on Snowflake?
-
-{% set exclude_field = 'FIELD_3' if target.type == 'snowflake' else 'field_3' %}
+{% set exclude_field = 'field_3' %}
 
 
 with data as (

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -13,7 +13,7 @@
 
     {%- for col in cols -%}
 
-        {%- if col.column not in except -%}
+        {%- if col.column|lower not in except|map('lower') -%}
             {% do include_cols.append(col.column) %}
 
         {%- endif %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [ ] new functionality
- [x] a breaking change

## Description & motivation

This change makes the `except` parameter of the `star` macro case insensitive.

We encountered this issue as we are migrating from Postgres to Snowflake and we lowercase all of our column names in the `except` argument.

This could be a breaking change if you have different columns with different casing but this seems like a very bad practice, for example `timestamp` and `Timestamp` in the same table. I haven't included an entry in the changelog yet because I am not sure if this is considered a fix/feature/breaking change.

See discussion here: https://github.com/fishtown-analytics/dbt-utils/issues/115

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to the changelog
