### PR TITLE
Add argument to get_column_values allow for alternate sorting of column values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt-utils v0.6.3
+
+## Features
+- Adds ability to specify a `sort_column` and `sort_direction` in `get_column_values.
+
 # dbt-utils v0.6.2
 
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ group by 1
 This macro returns the unique values for a column in a given [relation](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation).
 It takes an options `default` argument for compiling when the relation does not already exist.
 
+The `sort_column` argument allows for sorting of values. The default is highest to lowest frequency of values. You can also specify a `sort_direction`.
+
 Usage:
 ```
 -- Returns a list of the top 50 states in the `users` table
@@ -453,6 +455,29 @@ Usage:
 
 ...
 ```
+
+```
+-- Returns a list of user names sorted by name from the `users` table
+{% set names = dbt_utils.get_column_values(table=ref('users'), column='name', sort_column='name', default=[]) %}
+
+{% for name in names %}
+    ...
+{% endfor %}
+
+...
+```
+
+```
+-- Returns a list of user cities sorted by name from the `users` table
+{% set cities = dbt_utils.get_column_values(table=ref('users'), column='city_name', sort_column='city_name', default=[]) %}
+
+{% for city in cities %}
+    ...
+{% endfor %}
+
+...
+```
+
 #### get_relations_by_prefix
 Returns a list of [Relations](https://docs.getdbt.com/docs/writing-code-in-dbt/class-reference/#relation)
 that match a given prefix, with an optional exclusion pattern. It's particularly


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [x] new functionality
- [ ] a breaking change

## Description & motivation
This PR adds a `sort_column` and `sort_direction` argument to `get_column_values` to allow for alternate sorting of column values. This based on work from @joshpeng-quibi
Closes #288 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to the changelog
