### PR TITLE
Fix SQL Server String Type and add sqlserver__get_tables_by_pattern_sql

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
-name: 'dbt_utils'
-version: '0.1.0'
+name: 'dbt_sqlserver_utils'
+version: '0.0.1'
 
 require-dbt-version: [">=0.18.0", "<0.19.0"]
 config-version: 2

--- a/macros/cross_db_utils/datatypes.sql
+++ b/macros/cross_db_utils/datatypes.sql
@@ -12,6 +12,10 @@
     varchar
 {%- endmacro -%}
 
+{%- macro sqlserver__type_string() -%}
+    VARCHAR
+{%- endmacro -%}
+
 {% macro postgres__type_string() %}
     varchar
 {% endmacro %}

--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -15,6 +15,18 @@
 {% endmacro %}
 
 
+{% macro sqlserver__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+        SELECT DISTINCT
+            table_schema AS "table_schema",
+            table_name AS "table_name"
+        FROM {{database}}.information_schema.tables
+        WHERE table_schema LIKE '{{ schema_pattern }}'
+        AND table_name LIKE '{{ table_pattern }}'
+        AND table_name NOT LIKE '{{ exclude }}'
+
+{% endmacro %}
+
 {% macro bigquery__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
     {% if '%' in schema_pattern %}


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes (please change the base branch to `main`)
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
This PR enables the dbt-utils package to work more effectively with the dbt-sqlserver and dbt-synapse projects. 

Running with the dbt-sqlserver type adapter: 

Test models - 14.
Failing models before changes -  11
Failing models after changes - 4
Unpivot and pivot are both fixed by change (at least assuming  the test models are accurate tests)
Union relations is also fixed. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [x] Synapse

Do note - change only effects synapse and SQL server. 

- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have not added an entry to the changelog - but I can. Is the idea to up the version every PR or? 
