### PR TITLE
Added `where` parameter to the `unique_combination_of_columns` schema test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # dbt-utils v0.7.0 (unreleased)
+* Added optional `where` clause in `unique_combination_of_columns` test macro [#295](https://github.com/fishtown-analytics/dbt-utils/pull/295) [findinpath](https://github.com/findinpath)
 
 ## Features
 * Add new `accepted_range` test ([#276](https://github.com/fishtown-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))

--- a/README.md
+++ b/README.md
@@ -418,6 +418,19 @@ An optional `quote_columns` parameter (`default=false`) can also be used if a co
         quote_columns: true
 ```
 
+An optional `where` parameter can also be used in order to isolate the rows of the data set on which the uniqueness
+constraint needs to be verified.
+
+```yaml
+- name: revenue_by_product_by_month
+  tests:
+    - dbt_utils.unique_combination_of_columns:
+        combination_of_columns:
+          - month
+          - group
+        where: year >= 2020
+```
+
 
 #### accepted_range ([source](macros/schema_tests/accepted_range.sql))
 This test checks that a column's values fall inside an expected range. Any combination of `min_value` and `max_value` is allowed, and the range can be inclusive or exclusive. Provide a `where` argument to filter to specific records only. 

--- a/macros/schema_tests/unique_combination_of_columns.sql
+++ b/macros/schema_tests/unique_combination_of_columns.sql
@@ -1,12 +1,11 @@
-{% macro test_unique_combination_of_columns(model, quote_columns = false) %}
+{% macro test_unique_combination_of_columns(model, combination_of_columns, quote_columns = false, where = None) %}
 
-{%- set columns = kwargs.get('combination_of_columns', kwargs.get('arg')) %}
 
 {% if not quote_columns %}
-    {%- set column_list=columns %}
+    {%- set column_list=combination_of_columns %}
 {% elif quote_columns %}
     {%- set column_list=[] %}
-        {% for column in columns -%}
+        {% for column in combination_of_columns -%}
             {% set column_list = column_list.append( adapter.quote(column) ) %}
         {%- endfor %}
 {% else %}
@@ -23,7 +22,7 @@ with validation_errors as (
     select
         {{ columns_csv }}
     from {{ model }}
-
+    {% if where %}where {{ where }} {% endif %}
     group by {{ columns_csv }}
     having count(*) > 1
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [x] new functionality
- [ ] a breaking change

## Description & motivation
This PR adds `where` parameter to the `unique_combination_of_columns` schema test in order to support a `WHERE` clause that can be used to isolate the tuples on which the uniqueness for the combination of columns needs to be verified.


## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to the changelog
