### PR TITLE
Allow dbt v0.19.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             echo $BIGQUERY_SERVICE_ACCOUNT_JSON > ${HOME}/bigquery-service-key.json
 
       - restore_cache:
-          key: deps1-{{ .Branch }}
+          key: deps2-{{ .Branch }}
 
       - run:
           name: "Run Tests - Postgres"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=0.18.0", "<0.19.0"]
+require-dbt-version: [">=0.18.0", "<0.20.0"]
 config-version: 2
 
 target-path: "target"

--- a/run_test.sh
+++ b/run_test.sh
@@ -6,7 +6,7 @@ if [[ ! -f $VENV ]]; then
     . $VENV
 
     pip install --upgrade pip setuptools
-    pip install  "dbt>=0.18.0,<0.19.0"
+    pip install  "dbt>=0.18.0,<0.20.0"
 fi
 
 . $VENV

--- a/run_test.sh
+++ b/run_test.sh
@@ -6,7 +6,7 @@ if [[ ! -f $VENV ]]; then
     . $VENV
 
     pip install --upgrade pip setuptools
-    pip install  "dbt>=0.18.0,<0.20.0"
+    pip install --pre "dbt<0.20.0"
 fi
 
 . $VENV


### PR DESCRIPTION
## Description & motivation
- Resolves #308
- Bumps upper bound to allow dbt v0.19.0, which has no breaking changes
- Since there are no breaking changes, I'd love to cut a patch release of dbt-utils that bumps its upper bounds _before_ the final release of v0.19.0. This would make it easier for folks to test v0.19.0-rc1, since it obviates the need to explicitly pass `--no-version-check`.

## TODO
- [x] Wait until v0.19.0-rc1 is released on pypi

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [x] I have added an entry to CHANGELOG.md
