### PR TITLE
t-sql hacks that shouldn't break mainline behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix `equality` test when used with ephemeral models + explicit column set ([#321](https://github.com/fishtown-analytics/dbt-utils/pull/321))
 - Fix `get_query_results_as_dict` integration test with consistent ordering ([#322](https://github.com/fishtown-analytics/dbt-utils/pull/322))
 - All macros are now properly dispatched, making it possible for non-core adapters to implement a shim package for dbt-utils ([#312](https://github.com/fishtown-analytics/dbt-utils/pull/312)) Thanks [@chaerinlee1](https://github.com/chaerinlee1) and [@swanderz](https://github.com/swanderz)
+- Small, non-breaking changes to accomdate TSQL (can't group by column number references, no real TRUE/FALSE values, aggregation CTEs need named columns) ([#310](https://github.com/fishtown-analytics/dbt-utils/pull/310)) Thanks [@swanderz](https://github.com/swanderz)
 
 # dbt-utils v0.6.3
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -19,6 +19,9 @@ clean-targets:         # directories to be removed by `dbt clean`
     - "target"
     - "dbt_modules"
 
+vars:
+  dbt_utils_dispatch_list: ['dbt_utils_integration_tests']
+
 seeds:
 
   +quote_columns: false

--- a/integration_tests/macros/limit_zero.sql
+++ b/integration_tests/macros/limit_zero.sql
@@ -1,0 +1,7 @@
+{% macro limit_zero() %}
+    {{ return(adapter.dispatch('limit_zero', dbt_utils._get_utils_namespaces())()) }}
+{% endmacro %}
+
+{% macro default__limit_zero() %}
+    {{ return('limit 0') }}
+{% endmacro %}

--- a/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
+++ b/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
@@ -77,5 +77,5 @@ Instead, we'll manually check that the values of these dictionaries are equivale
 {% endif %}
 
 {{ log(ns.err_msg, info=True) }}
-select 1 as col_name {% if ns.pass %} where 0=1 {% endif %}
+select 1 as col_name {% if ns.pass %} {{ limit_zero }} {% endif %}
 {% endif %}

--- a/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
+++ b/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
@@ -77,5 +77,5 @@ Instead, we'll manually check that the values of these dictionaries are equivale
 {% endif %}
 
 {{ log(ns.err_msg, info=True) }}
-select 1 {% if ns.pass %} limit 0 {% endif %}
+select 1 as col_name {% if ns.pass %} where 0=1 {% endif %}
 {% endif %}

--- a/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
+++ b/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
@@ -77,5 +77,5 @@ Instead, we'll manually check that the values of these dictionaries are equivale
 {% endif %}
 
 {{ log(ns.err_msg, info=True) }}
-select 1 as col_name {% if ns.pass %} {{ limit_zero }} {% endif %}
+select 1 as col_name {% if ns.pass %} {{ limit_zero() }} {% endif %}
 {% endif %}

--- a/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_log_format() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 limit 0
+    select 1 as col_name where 0=1
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_log_format() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name where 0=1
+    select 1 as col_name {{ limit_zero }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_output_msg_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_log_format() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name {{ limit_zero }}
+    select 1 as col_name {{ limit_zero() }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_time_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_time_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_time() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name where 0=1
+    select 1 as col_name FROM DUAL where 0=1
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_time_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_time_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_time() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 limit 0
+    select 1 as col_name where 0=1
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_time_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_time_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_time() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name FROM DUAL where 0=1
+    select 1 as col_name {{ limit_zero }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/integration_tests/tests/logger/assert_pretty_time_is_string.sql
+++ b/integration_tests/tests/logger/assert_pretty_time_is_string.sql
@@ -1,6 +1,6 @@
 {% if dbt_utils.pretty_time() is string %}
     {# Return 0 rows for the test to pass #}
-    select 1 as col_name {{ limit_zero }}
+    select 1 as col_name {{ limit_zero() }}
 {% else %}
     {# Return >0 rows for the test to fail #}
     select 1

--- a/macros/schema_tests/at_least_one.sql
+++ b/macros/schema_tests/at_least_one.sql
@@ -5,9 +5,9 @@
 select count(*)
 from (
     select
-        {# subquery aggregate columns need aliases #}
-        {# thus: 'unique_values' #}
-      count({{ column_name }}) as unique_values
+        {# In TSQL, subquery aggregate columns need aliases #}
+        {# thus: a filler col name, 'filler_column' #}
+      count({{ column_name }}) as filler_column
 
     from {{ model }}
 

--- a/macros/schema_tests/at_least_one.sql
+++ b/macros/schema_tests/at_least_one.sql
@@ -5,8 +5,9 @@
 select count(*)
 from (
     select
-
-      count({{ column_name }})
+        {# subquery aggregate columns need aliases #}
+        {# thus: 'unique_values' #}
+      count({{ column_name }}) as unique_values
 
     from {{ model }}
 

--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -1,5 +1,6 @@
 {% macro test_cardinality_equality(model, to, field) %}
-
+{# T-SQL doesn't let you use numbers as aliases for columns #}
+{# Thus, no "GROUP BY 1" #}
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
 
 
@@ -8,7 +9,7 @@ select
   {{ column_name }},
   count(*) as num_rows
 from {{ model }}
-group by 1
+group by {{ column_name }}
 ),
 
 table_b as (
@@ -16,7 +17,7 @@ select
   {{ field }},
   count(*) as num_rows
 from {{ to }}
-group by 1
+group by {{ column_name }}
 ),
 
 except_a as (

--- a/macros/schema_tests/expression_is_true.sql
+++ b/macros/schema_tests/expression_is_true.sql
@@ -1,5 +1,6 @@
-{% macro test_expression_is_true(model, condition='true') %}
-
+{% macro test_expression_is_true(model, condition='1=1') %}
+{# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
+{# ref https://stackoverflow.com/a/7170753/3842610 #}
 {% set expression = kwargs.get('expression', kwargs.get('arg')) %}
 
 with meet_condition as (

--- a/macros/schema_tests/not_constant.sql
+++ b/macros/schema_tests/not_constant.sql
@@ -8,6 +8,8 @@ select count(*)
 from (
 
     select
+          {# In TSQL, subquery aggregate columns need aliases #}
+          {# thus: a filler col name, 'filler_column' #}
           count(distinct {{ column_name }}) as filler_column
 
     from {{ model }}

--- a/macros/schema_tests/not_constant.sql
+++ b/macros/schema_tests/not_constant.sql
@@ -8,7 +8,7 @@ select count(*)
 from (
 
     select
-          count(distinct {{ column_name }})
+          count(distinct {{ column_name }}) as filler_column
 
     from {{ model }}
 

--- a/macros/schema_tests/relationships_where.sql
+++ b/macros/schema_tests/relationships_where.sql
@@ -1,6 +1,8 @@
 {% macro test_relationships_where(model, to, field) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
+{# T-SQL has no boolean data type so we use 1=1 which returns TRUE #}
+{# ref https://stackoverflow.com/a/7170753/3842610 #}
 {% set from_condition = kwargs.get('from_condition', "1=1") %}
 {% set to_condition = kwargs.get('to_condition', "1=1") %}
 

--- a/macros/schema_tests/relationships_where.sql
+++ b/macros/schema_tests/relationships_where.sql
@@ -1,8 +1,8 @@
 {% macro test_relationships_where(model, to, field) %}
 
 {% set column_name = kwargs.get('column_name', kwargs.get('from')) %}
-{% set from_condition = kwargs.get('from_condition', "true") %}
-{% set to_condition = kwargs.get('to_condition', "true") %}
+{% set from_condition = kwargs.get('from_condition', "1=1") %}
+{% set to_condition = kwargs.get('to_condition', "1=1") %}
 
 with left_table as (
 


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
MSFT's T-SQL has some weird quirks to it such as:
- subquery aggregate columns need aliases; and
- there is no boolean type, so there's no such thing as `true` and `false`. So in a few schema tests, I've replaced `true` with `1=1`; and,
- `limit 0` at the end of the query translates in TSQL to `SELECT TOP (0)`. If the purpose is to return zero rows, `WHERE 0=1` will accomplish the same more universally.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
