### PR TITLE
Make expression_is_true test work as a column test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Features
 * Add new `accepted_range` test ([#276](https://github.com/fishtown-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))
+* Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/fishtown-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313]) 
 
 # dbt-utils v0.6.2
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,25 @@ models:
 
 ```
 
+This macro can also be used at the column level. When this is done, the `expression` is evaluated against the column.  
+
+```yaml
+version: 2
+models: 
+    - name: model_name
+      columns: 
+        - name: col_a
+          tests:
+            - dbt_utils.expression_is_true:
+                expression: '>= 1'
+        - name: col_b
+          tests:
+            - dbt_utils.expression_is_true:
+                expression: '= 1'
+                condition: col_a = 1
+      
+```
+
 
 #### recency ([source](macros/schema_tests/recency.sql))
 This schema test asserts that there is data in the referenced model at least as recent as the defined interval prior to the current timestamp.

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -20,6 +20,16 @@ models:
       - dbt_utils.expression_is_true:
           expression: col_a = 0.5
           condition: col_b = 0.5
+    columns:
+      - name: col_a
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: + col_b = 1
+      - name: col_b
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: = 0.5
+              condition: col_a = 0.5
 
   - name: test_recency
     tests:

--- a/macros/schema_tests/expression_is_true.sql
+++ b/macros/schema_tests/expression_is_true.sql
@@ -1,6 +1,7 @@
 {% macro test_expression_is_true(model, condition='true') %}
 
 {% set expression = kwargs.get('expression', kwargs.get('arg')) %}
+{% set column_name = kwargs.get('column_name') %}
 
 with meet_condition as (
 
@@ -12,7 +13,7 @@ validation_errors as (
     select
         *
     from meet_condition
-    where not({{expression}})
+    where not( {{ expression if column_name is none else [column_name, expression] | join(' ')  }})
 
 )
 

--- a/macros/schema_tests/expression_is_true.sql
+++ b/macros/schema_tests/expression_is_true.sql
@@ -13,7 +13,11 @@ validation_errors as (
     select
         *
     from meet_condition
-    where not( {{ expression if column_name is none else [column_name, expression] | join(' ')  }})
+    {% if column_name is none %}
+    where not({{ expression }})
+    {%- else %}
+    where not({{ column_name }} {{ expression }})
+    {%- endif %}
 
 )
 


### PR DESCRIPTION
Opening in favor of #226

This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
From #226:
> I love the expression_is_true schema test, but often it feels like the tests I use them for should be a child of the column I'm testing against, instead of the whole relationship. So I modified the expression_is_true test to do exactly that.

Left the original tests as is (no regressions), and added 2 more tests to test with condition set and without it.


## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have added an entry to CHANGELOG.md
