### PR TITLE
Make queue first step of workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 
 version: 2.1
 
+orbs:
+  queue: eddiewebb/queue@1.5.0
+
 jobs:
   
   integration-postgres:
@@ -64,7 +67,10 @@ workflows:
   version: 2
   test-all:
     jobs:
-      - integration-postgres
+      - queue/block_workflow
+      - integration-postgres:
+          requires:
+            - queue/block_workflow
       - integration-redshift:
           requires:
             - integration-postgres


### PR DESCRIPTION
Building  on #316 

This might help us out when we have the issue of two branches being updated at once, causing overlapping runs on a particular database.



The current failure message indicates that some work needs to be done on the CircleCI side. We might also need to add an API key to get their working, as per the [docs](https://circleci.com/developer/orbs/orb/eddiewebb/queue)