### PR TITLE
broken commit: update internals of insert by period

### DIFF
--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -142,7 +142,9 @@
           from {{tmp_relation.include(schema=False)}}
       );
     {%- endcall %}
-    {%- set rows_inserted = (load_result('main-' ~ i)['status'].split(" "))[2] | int -%}
+    {% set result = load_result('main-' ~ i) %}
+    {% set rows_inserted = result['response']['rows_affected'] %}
+    {% endif %}
     {%- set sum_rows_inserted = loop_vars['sum_rows_inserted'] + rows_inserted -%}
     {%- if loop_vars.update({'sum_rows_inserted': sum_rows_inserted}) %} {% endif -%}
 
@@ -165,7 +167,7 @@
 
   {%- set status_string = "INSERT " ~ loop_vars['sum_rows_inserted'] -%}
 
-  {% call noop_statement(name='main', status=status_string) -%}
+  {% call noop_statement(name='main', message=status_string) -%}
     -- no-op
   {%- endcall %}
 

--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -143,8 +143,12 @@
       );
     {%- endcall %}
     {% set result = load_result('main-' ~ i) %}
-    {% set rows_inserted = result['response']['rows_affected'] %}
+    {% if 'response' in result.keys() %} {# added in v0.19.0 #}
+        {% set rows_inserted = result['response']['rows_affected'] %}
+    {% else %} {# older versions #}
+        {% set rows_inserted = result['status'].split(" ")[2] | int %}
     {% endif %}
+    
     {%- set sum_rows_inserted = loop_vars['sum_rows_inserted'] + rows_inserted -%}
     {%- if loop_vars.update({'sum_rows_inserted': sum_rows_inserted}) %} {% endif -%}
 
@@ -167,7 +171,7 @@
 
   {%- set status_string = "INSERT " ~ loop_vars['sum_rows_inserted'] -%}
 
-  {% call noop_statement(name='main', message=status_string) -%}
+  {% call noop_statement('main', status_string) -%}
     -- no-op
   {%- endcall %}
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -24,5 +24,8 @@ if [[ ! -z $3 ]]; then _seeds="--select $3 --full-refresh"; fi
 
 dbt deps --target $1
 dbt seed --target $1 $_seeds
+if [ $1 == 'redshift' ]; then
+    dbt run -x -m test_insert_by_period --full-refresh --target redshift
+fi
 dbt run -x --target $1 $_models
 dbt test -x --target $1 $_models


### PR DESCRIPTION
@jtcohen6 — this is what is broken, but I can't quite get it to work! not sure how to access the internals of the AdapterResponse class. Figured you would have a better idea than me :) 

Also — this would be classed as a breaking change, so we might want to write some logic about handling this on different versions of dbt to avoid the break.

I was curious as to how this snuck in, and went back to #309 — turns out it [silently failed](https://app.circleci.com/pipelines/github/fishtown-analytics/dbt-utils/199/workflows/4426f6ef-333b-4336-b3e3-31cff022dce4/jobs/700/parallel-runs/0/steps/0-105) back then! I think because the "test" step passed, even though the "run" step failed. Now that we are using `-x`, the job exits, causing other tests to fail, and the resultant error message.

I think the problem here is that we run the steps via the `run_test.sh` file, when potentially we want them as separate (parameterized?) steps in the CircleCI workflow.