### PR TITLE
Fix: insert by period for 0.19

### DIFF
--- a/macros/materializations/insert_by_period_materialization.sql
+++ b/macros/materializations/insert_by_period_materialization.sql
@@ -143,8 +143,12 @@
       );
     {%- endcall %}
     {% set result = load_result('main-' ~ i) %}
-    {% set rows_inserted = result['response']['rows_affected'] %}
+    {% if 'response' in result.keys() %} {# added in v0.19.0 #}
+        {% set rows_inserted = result['response']['rows_affected'] %}
+    {% else %} {# older versions #}
+        {% set rows_inserted = result['status'].split(" ")[2] | int %}
     {% endif %}
+    
     {%- set sum_rows_inserted = loop_vars['sum_rows_inserted'] + rows_inserted -%}
     {%- if loop_vars.update({'sum_rows_inserted': sum_rows_inserted}) %} {% endif -%}
 
@@ -167,7 +171,7 @@
 
   {%- set status_string = "INSERT " ~ loop_vars['sum_rows_inserted'] -%}
 
-  {% call noop_statement(name='main', message=status_string) -%}
+  {% call noop_statement('main', status_string) -%}
     -- no-op
   {%- endcall %}
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -24,5 +24,8 @@ if [[ ! -z $3 ]]; then _seeds="--select $3 --full-refresh"; fi
 
 dbt deps --target $1
 dbt seed --target $1 $_seeds
+if [ $1 == 'redshift' ]; then
+    dbt run -x -m test_insert_by_period --full-refresh --target redshift
+fi
 dbt run -x --target $1 $_models
 dbt test -x --target $1 $_models


### PR DESCRIPTION
Extends #319, fixup of #309 (v0.6.3)

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

- Update `insert_by_period` in a way that should be compatible for v0.19.0 _and_ earlier versions. I'm hoping we can release this as a patch to 0.6.3, rather than a new minor version :) I tested on v0.19.0-rc1 and v0.18.1.
- Include a `--full-refresh` step to build `test_insert_by_period` twice

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [ ] Snowflake
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [ ] I have added an entry to CHANGELOG.md
