### PR TITLE
Fix equality test with ephemeral model + explicit column set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# dbt-utils v0.6.4
+
+- Fix `insert_by_period` to support `dbt v0.19.0`, with backwards compatibility for earlier versions ([#319](https://github.com/fishtown-analytics/dbt-utils/pull/319), [#320](https://github.com/fishtown-analytics/dbt-utils/pull/320))
+- Speed up CI via threads, workflows ([#315](https://github.com/fishtown-analytics/dbt-utils/pull/315), [#316](https://github.com/fishtown-analytics/dbt-utils/pull/316))
+- Fix `equality` test when used with ephemeral models + explicit column set ([#321](https://github.com/fishtown-analytics/dbt-utils/pull/321))
+
+# dbt-utils v0.6.3
+
+- Bump `require-dbt-version` to `[">=0.18.0", "<0.20.0"]` to support dbt v0.19.0 ([#308](https://github.com/fishtown-analytics/dbt-utils/pull/308), [#309](https://github.com/fishtown-analytics/dbt-utils/pull/309))
+
+## Fixes
+
 # dbt-utils v0.6.2
 
 ## Fixes

--- a/macros/schema_tests/equality.sql
+++ b/macros/schema_tests/equality.sql
@@ -13,12 +13,14 @@
 If the compare_cols arg is provided, we can run this test without querying the
 information schema — this allows the model to be an ephemeral model
 -#}
-{%- if not kwargs.get('compare_columns', None) -%}
+{%- set compare_columns = kwargs.get('compare_columns', None) -%}
+
+{%- if not compare_columns -%}
     {%- do dbt_utils._is_ephemeral(model, 'test_equality') -%}
+    {%- set compare_columns = adapter.get_columns_in_relation(model) | map(attribute='quoted') -%}
 {%- endif -%}
 
 {% set compare_model = kwargs.get('compare_model', kwargs.get('arg')) %}
-{% set compare_columns = kwargs.get('compare_columns', adapter.get_columns_in_relation(model) | map(attribute='quoted') ) %}
 {% set compare_cols_csv = compare_columns | join(', ') %}
 
 with a as (


### PR DESCRIPTION
See: https://github.com/fishtown-analytics/spark-utils/issues/7

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

If `equality` is comparing an ephemeral model with the `compare_columns` keyword argument, we want to avoid running `adapter.get_columns_in_relation(model)` entirely.

Currently, it is the default/fallback arg to `kwargs.get()`. Instead, we should place it inside a conditional that only runs if `kwargs.get(compare_columns)` returns none. I was under the impression that these were effectively the same, but this change actually fixes an integration test (`test_equal_column_subset`) on `dbt-utils` + `spark-utils`.

Why did this only break with Spark? Because `dbt-spark` uses `describe table [table_name]` to get the columns from a given table, a command that fails if the table does not exist. Most "core" adapters query the information schema instead; if the table doesn't exist, the query returns no results, but it doesn't fail explicitly.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
    - [x] Spark
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [x] I have added an entry to CHANGELOG.md
