### PR TITLE
Fix: get_query_results_as_dict integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # dbt-utils v0.6.4
 
+### Fixes
 - Fix `insert_by_period` to support `dbt v0.19.0`, with backwards compatibility for earlier versions ([#319](https://github.com/fishtown-analytics/dbt-utils/pull/319), [#320](https://github.com/fishtown-analytics/dbt-utils/pull/320))
+
+### Under the hood
 - Speed up CI via threads, workflows ([#315](https://github.com/fishtown-analytics/dbt-utils/pull/315), [#316](https://github.com/fishtown-analytics/dbt-utils/pull/316))
 - Fix `equality` test when used with ephemeral models + explicit column set ([#321](https://github.com/fishtown-analytics/dbt-utils/pull/321))
+- Fix `get_query_results_as_dict` integration test with consistent ordering ([#322](https://github.com/fishtown-analytics/dbt-utils/pull/322))
 
 # dbt-utils v0.6.3
 

--- a/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
+++ b/integration_tests/tests/assert_get_query_results_as_dict_objects_equal.sql
@@ -17,7 +17,7 @@
 
 
 {% set actual_dictionary=dbt_utils.get_query_results_as_dict(
-    "select * from " ~ ref('data_get_query_results_as_dict')
+    "select * from " ~ ref('data_get_query_results_as_dict') ~ " order by 1"
 ) %}
 {#-
 For reasons that remain unclear, Jinja won't return True for actual_dictionary == expected_dictionary.


### PR DESCRIPTION
This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

See: https://github.com/fishtown-analytics/spark-utils/issues/7

Unless a query contains `order by`, its order is not deterministic on analytical databases / data processing technologies. This test is currently failing on Spark even though `dbt_utils.get_query_results_as_dict()` works just fine.

I believe that `order by 1` is supported on all known adapters.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Postgres
    - [x] Redshift
    - [x] Snowflake
- ~I have updated the README.md (if applicable)~
- ~I have added tests & descriptions to my models (and macros if applicable)~
- [ ] I have added an entry to CHANGELOG.md
