### PR TITLE
support quarter in postgres last day

### DIFF
--- a/integration_tests/data/cross_db/data_last_day.csv
+++ b/integration_tests/data/cross_db/data_last_day.csv
@@ -1,4 +1,5 @@
 date_day,date_part,result
 2018-01-02,month,2018-01-31
+2018-01-02,quarter,2018-03-31
 2018-01-02,year,2018-12-31
 ,month,

--- a/integration_tests/models/cross_db_utils/test_last_day.sql
+++ b/integration_tests/models/cross_db_utils/test_last_day.sql
@@ -8,6 +8,7 @@ with data as (
 select
     case
         when date_part = 'month' then {{ dbt_utils.last_day('date_day', 'month') }}
+        when date_part = 'quarter' then {{ dbt_utils.last_day('date_day', 'quarter') }}
         when date_part = 'year' then {{ dbt_utils.last_day('date_day', 'year') }}
         else null
     end as actual,

--- a/macros/cross_db_utils/last_day.sql
+++ b/macros/cross_db_utils/last_day.sql
@@ -25,8 +25,12 @@ testing is required to validate that it will work on other dateparts.
 {% macro postgres__last_day(date, datepart) -%}
 
     {%- if datepart == 'quarter' -%}
-    {{ exceptions.raise_compiler_error(
-        "dbt_utils.last_day is not supported for datepart 'quarter' on this adapter") }}
+    -- postgres dateadd does not support quarter interval.
+    cast(
+        {{dbt_utils.dateadd('day', '-1',
+        dbt_utils.dateadd('month', '3', dbt_utils.date_trunc(datepart, date))
+        )}}
+        as date)
     {%- else -%}
     {{dbt_utils.default_last_day(date, datepart)}}
     {%- endif -%}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
The existing macro `last_day` does not support `quarter` because postgres does not support `quarter` interval. I've updated to use 3 months when datepart is quarter, so the same sql can be used in the supported databases.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
