### PR TITLE
Fix regression with cardinality equality when field names are different

### DIFF
--- a/macros/schema_tests/cardinality_equality.sql
+++ b/macros/schema_tests/cardinality_equality.sql
@@ -25,7 +25,7 @@ select
   {{ field }},
   count(*) as num_rows
 from {{ to }}
-group by {{ column_name }}
+group by {{ field }}
 ),
 
 except_a as (


### PR DESCRIPTION
Resolves a bug introduced in #310

This is a:
- [x] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
I started getting a cardinality equality test failure after upgrading from 0.6.2 to 0.6.4 (as part of upgrading dbt from 0.18.1 to 0.19.1).  Turns out that the SQL wasn't being written properly when the column being tested and the reference didn't use the same name.

## Checklist
**NOTE:** I would love to have written tests for this but struggled getting started.  There didn't seem to be an existing test for this macro, so I didn't have much to go on.  Also, when I ran `make test target=postgres` according to [these instructions](https://github.com/fishtown-analytics/dbt-utils/blob/master/integration_tests/README.md), I got the error `Could not render {{ env_var('POSTGRES_TEST_HOST') }}: Env var required but not provided: 'POSTGRES_TEST_HOST'`.  It wasn't clear to me how to resolve this without much deeper work, so I gave up.

- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [x] I have updated the README.md (if applicable) - **N/A**
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md - **Not clear where you want me to put the changes as there's no section for unreleased/upcoming versions**.
