### PR TITLE
Upfront ask to dispatch new macros

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@ This is a:
 - [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
 - [ ] new functionality — please ensure the base branch is the latest `dev/` branch
 - [ ] a breaking change — please ensure the base branch is the latest `dev/` branch
-- [ ] a new macro — please ensure the macro is properly dispatched (for an example check out [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
 
 ## Description & motivation
 <!---
@@ -15,6 +14,7 @@ Describe your changes, and why you're making them.
     - [ ] Postgres
     - [ ] Redshift
     - [ ] Snowflake
+- [ ] I have "dispatched" any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
 - [ ] I have updated the README.md (if applicable)
 - [ ] I have added tests & descriptions to my models (and macros if applicable)
 - [ ] I have added an entry to CHANGELOG.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@ This is a:
 - [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
 - [ ] new functionality — please ensure the base branch is the latest `dev/` branch
 - [ ] a breaking change — please ensure the base branch is the latest `dev/` branch
+- [ ] a new macro — please ensure the macro is properly dispatched (for an example check out [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
 
 ## Description & motivation
 <!---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# dbt-utils v0.6.5 (unreleased)
+# dbt-utils v0.6.5
 ## Features
 * Add new `accepted_range` test ([#276](https://github.com/fishtown-analytics/dbt-utils/pull/276) [@joellabes](https://github.com/joellabes))
 * Make `expression_is_true` work as a column test (code originally in [#226](https://github.com/fishtown-analytics/dbt-utils/pull/226/) from [@elliottohara](https://github.com/elliottohara), merged via [#313])


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [ ] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation

To get tsql-utils current with `0.6.5` (https://github.com/dbt-msft/tsql-utils/pull/49), I had to disable many new tests that went with new macros. When undispatched macros are added to dbt-utils, it requires two PRs to get the new macro working with TSQL:
1. a PR to dbt-utils to allow the new macro to be dispatched
2. a PR to tsql-utils adding the shim logic for the new macro.

My proposal would be to strive for all new proposed macros to have dispatch logic before merging. The rationale being:
- IIRC, releases can't be used for submodules, yet
- submodules are how the shim packages (tsql-utils, spark-utils, presto-utils) import dbt-utils.

This makes it hard to selectively add new functionality to the shim packages without taking all commits to master


## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
