### PR TITLE
Fix: return 0 in `equal_rowcount` when both models have 0 rows

### DIFF
--- a/macros/generic_tests/equal_rowcount.sql
+++ b/macros/generic_tests/equal_rowcount.sql
@@ -5,7 +5,7 @@
 {% macro default__test_equal_rowcount(model, compare_model, group_by_columns) %}
 
 {#-- Needs to be set at parse time, before we return '' below --#}
-{{ config(fail_calc = 'sum(coalesce(diff_count, 0))') }}
+{{ config(fail_calc = 'coalesce(sum(diff_count), 0)') }}
 
 {#-- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
 {%- if not execute -%}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-utils/issues/973

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
Currently, when using the equal_rowcount test with two models that have zero rows, the test incorrectly returns NULL instead of 0. This leads to test failures, as NULL values are treated as errors in the test.
<img width="975" alt="スクリーンショット 2024-12-25 12 49 58" src="https://github.com/user-attachments/assets/d00e7587-b5d4-4ca7-8832-6338b80f61ce" />

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->
This PR modifies the equal_rowcount test to return 0 when both models being compared have zero rows, instead of returning NULL. This change ensures that the test passes as expected in scenarios where both models contain no data. 
<img width="975" alt="スクリーンショット 2024-12-25 12 50 03" src="https://github.com/user-attachments/assets/3e7eb91e-b5d8-4c2e-9f84-b4e857d8857e" />

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
