### PR TITLE
Fix logic to not reset the variable - Fusion impact

### DIFF
--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -9,7 +9,7 @@
 {% elif quote_columns %}
     {%- set column_list=[] %}
         {% for column in combination_of_columns -%}
-            {% set column_list = column_list.append( adapter.quote(column) ) %}
+            {% do column_list.append( adapter.quote(column) ) %}
         {%- endfor %}
 {% else %}
     {{ exceptions.raise_compiler_error(


### PR DESCRIPTION
Related to https://github.com/dbt-labs/dbt-fusion/issues/484

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->
While the following works in dbt-core
```
{% set column_list = column_list.append( adapter.quote(column) ) %}
```

It is very much a typo, but it just works in dbt-core/Jinja.

It doesn't in Fusion though as `append` returns None instead of returning the list.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

The solution is to use the proper logic of not resetting the var.
```
{% do column_list.append( adapter.quote(column) ) %}
```

## Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
