### PR TITLE
Chore: Postgresql and Python version bumps for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
   
   integration-postgres:
     docker:
-      - image: cimg/python:3.9
-      - image: cimg/postgres:9.6
+      - image: cimg/python:3.13.7
+      - image: cimg/postgres:17.5
         environment:
           POSTGRES_USER: root
     environment:
@@ -33,7 +33,7 @@ jobs:
 
   integration-redshift:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13.7
     steps:
       - checkout
       - run: pip install --pre dbt-redshift -r dev-requirements.txt
@@ -49,7 +49,7 @@ jobs:
 
   integration-snowflake:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13.7
     steps:
       - checkout
       - run: pip install --pre dbt-snowflake -r dev-requirements.txt
@@ -67,7 +67,7 @@ jobs:
     environment:
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.13.7
     steps:
       - checkout
       - run: pip install --pre dbt-bigquery -r dev-requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3.7"
 services:
   postgres:
-    image: cimg/postgres:9.6
+    image: cimg/postgres:17.5
     environment:
       - POSTGRES_USER=root
     ports:


### PR DESCRIPTION
- Bump the version of postgresql used by integration tests
- Bump the version of python used by integration tests
- Update docker compose syntax

resolves #1044 

### Problem

Outdated container images are being used.
The version field is deprecated in docker-compose files

### Solution

Use newer versions of container images from the CircleCI image repo
Remove the version field from the docker-compose.yml file

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
