### PR TITLE
Recency test to fail when no recent records are found

### DIFF
--- a/integration_tests/models/generic_tests/recency_with_where_filter.sql
+++ b/integration_tests/models/generic_tests/recency_with_where_filter.sql
@@ -1,0 +1,12 @@
+-- Test model with data that's intentionally old
+-- This simulates a scenario where we have data but it's all outside the recency window
+-- this should fail with a where clause but currently it would pass
+select
+    1 as id,
+    {{ dbt.dateadd('day', -10, dbt.current_timestamp()) }} as created_at
+
+union all
+
+select
+    2 as id,
+    {{ dbt.dateadd('day', -15, dbt.current_timestamp()) }} as created_at

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -261,3 +261,19 @@ models:
           compare_model: ref('data_test_equality_a')
           exclude_columns:
             - col_c
+
+  - name: recency_with_where_filter
+    data_tests:
+      # This test should FAIL and return 0 rows (test failure) because when we filter to id = 3,
+      # no records match the where condition, so most_recent will be null.
+      # Before the fix: test would incorrectly PASS (no rows returned)
+      # After the fix: test should correctly FAIL (returns the null row)
+      - dbt_utils.recency:
+          datepart: day
+          field: created_at
+          ignore_time_component: true
+          interval: 5
+          config:
+            where: "id = 3"  # This filters to no records since only id 1,2 exist
+            error_if: "<1"
+            warn_if: "<0"

--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -37,5 +37,6 @@ select
 
 from recency
 where most_recent < {{ threshold }}
+   or most_recent is null
 
 {% endmacro %}


### PR DESCRIPTION
  resolves #1041

  ### Problem

  <!---
    Describe the problem this PR is solving. What is the application state
    before this PR is merged?
  -->

  The `dbt_utils.recency` test incorrectly passes when a `where` clause filters
  out all records.

  **Current behavior**: When a `where` clause results in no matching records,
  `most_recent` becomes `NULL`. The test only checks `where most_recent < {{
  threshold }}`, but since `NULL < threshold` evaluates to `NULL` (not true), no
  rows are returned and the test incorrectly passes.

  **Expected behavior**: The test should fail when no recent data exists (even
  when filtered by a where clause), indicating missing recent data.

  ### Solution

  <!---
    Describe the way this PR solves the above problem. Add as much detail as you
    can to help reviewers understand your changes. Include any alternatives and
    tradeoffs you considered.
  -->

  Modified the `recency` macro in `macros/generic_tests/recency.sql` to include
  `or most_recent is null` in the WHERE clause. This ensures that when a where
  clause filters out all records (causing `most_recent` to be null), the test
  correctly fails by returning the null row.

  **Changes made**:
  - Updated the WHERE condition from `where most_recent < {{ threshold }}` to
  `where most_recent < {{ threshold }} or most_recent is null`
  - Added integration test `recency_with_where_filter` that reproduces the
  original bug and verifies the fix
  - Test uses data with old timestamps (10-15 days) and a where clause that
  filters to non-existent records

  **Testing approach**:
  - Before fix: Test incorrectly passes (returns 0 rows)
  - After fix: Test correctly fails (returns 1 row with null `most_recent`)
  - Verified existing recency tests continue to work as expected

  ## Checklist
  - [x] This code is associated with an
  [issue](https://github.com/dbt-labs/dbt-utils/issues/1041) which has been
  triaged and [accepted for development](https://docs.getdbt.com/docs/contributin
  g/oss-expectations#pull-requests).
  - [x] I have read [the contributing 
  guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and
  understand what's expected of me
  - [x] I have run this code in development and it appears to resolve the stated
  issue
  - [x] This PR includes tests, or tests are not required/relevant for this PR
  - [x] I have updated the README.md (if applicable)
