### PR TITLE
Update `get_filtered_columns_in_relation` to return empty list in parsing mode

### DIFF
--- a/macros/sql/get_filtered_columns_in_relation.sql
+++ b/macros/sql/get_filtered_columns_in_relation.sql
@@ -8,7 +8,7 @@
 
     {# -- Prevent querying of db in parsing mode. This works because this macro does not create any new refs. #}
     {%- if not execute -%}
-        {{ return('') }}
+        {{ return([]) }}
     {% endif %}
 
     {%- set include_cols = [] %}


### PR DESCRIPTION
resolves #969

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

The documentation for dbt-audit-helper's compare and classify macros suggests using `dbt_utils.get_filtered_columns_in_relation` to pass in long column lists for comparison. However, doing so results in the compilation error below.

```
(venv) katieclaiborne@Mac dbt % dbt compile -s compare_and_classify_relation_rows -t main
19:18:48  Running with dbt=1.9.8
19:18:49  Registered adapter: bigquery=1.9.2
19:18:50  Encountered an error:
Compilation Error in analysis compare_and_classify_query_results (analyses/audit_helper/compare_and_classify_query_results.sql)
  can only concatenate list (not "str") to list
  
  > in macro compare_and_classify_query_results (macros/compare_and_classify_query_results.sql)
  > called by analysis compare_and_classify_query_results (analyses/audit_helper/compare_and_classify_query_results.sql)
```

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

As suggested in #969, I've updated the return type in parsing mode from string to list, so that the type is consistent across modes.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
