### PR TITLE
Pin GitHub Actions to specific SHAs (2 actions in 1 files)

### DIFF
--- a/.github/workflows/create-table-of-contents.yml
+++ b/.github/workflows/create-table-of-contents.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3
       - run: |
           curl https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc -o gh-md-toc
           chmod a+x gh-md-toc
           ./gh-md-toc --insert --no-backup README.md
           rm ./gh-md-toc
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a  # stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Auto update table of contents


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 2

### 📝 Changes by file

#### `.github/workflows/create-table-of-contents.yml`

- 📌 `actions/checkout@v3` → `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3`
- 📌 `stefanzweifel/git-auto-commit-action@v4` → `stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a  # stefanzweifel/git-auto-commit-action@v4`

