### PR TITLE
fix: Render relations to avoid including time filters in source_column_name

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -100,7 +100,7 @@
             select
 
                 {%- if source_column_name is not none %}
-                cast({{ dbt.string_literal(relation) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
+                cast({{ dbt.string_literal(relation.render()) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
                 {%- endif %}
 
                 {% for col_name in ordered_column_names -%}


### PR DESCRIPTION
resolves #
https://github.com/dbt-labs/dbt-utils/issues/1059

### Problem

If the model has event_time filters or micro-batch implemented the source_column_name returns the complete query for the relation like so
```
cast('(select * from "db"."sch"."em_bounces" where partition_date >= '2025-11-10 00:00:00+00:00' and partition_date < '2025-11-11 00:00:00+00:00')' as TEXT) as _dbt_source_relation,
```
This causes the macro to break and prevents setting up sampling and other related features.

This occurs because of the function in dbt-core [here](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/adapters/base/relation.py#L294) which is used in the [__str__](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/adapters/base/relation.py#L428) method that is used by `dbt.string_literal`.

### Solution

Use the 'render' method on the relation to obtain the relevant information as a string literal rather than the __str__ method of the relation.

It returns the expected SQL
```
WITH test_cte AS (



        (
            select
                cast('a.b.c' as TEXT) as source_system
```

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
