### PR TITLE
patch union_relations macro to avoid including 'collation' in cast

### DIFF
--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -2,6 +2,27 @@
     {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name, where)) }}
 {% endmacro %}
 
+{%- macro union_cast_type(data_type) -%}
+    {{ return(adapter.dispatch('union_cast_type', 'dbt_utils')(data_type)) }}
+{%- endmacro -%}
+
+{%- macro default__union_cast_type(data_type) -%}
+    {{ return(data_type) }}
+{%- endmacro -%}
+
+{%- macro snowflake__union_cast_type(data_type) -%}
+    {%- if data_type is none -%}
+        {{ return(none) }}
+    {%- endif -%}
+
+    {#-
+      Snowflake can return column types with collation metadata, e.g.
+      `varchar(100) collation 'en-ci'`. This is not valid inside `cast(... as <type>)`.
+    -#}
+    {%- set cleaned = modules.re.sub('(?i)\\s+collat(e|ion)\\s+.*$', '', data_type) -%}
+    {{ return(cleaned) }}
+{%- endmacro -%}
+
 {%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
 
     {%- if exclude and include -%}
@@ -113,6 +134,7 @@
 
                     {%- set col = column_superset[col_name] %}
                     {%- set col_type = column_override.get(col.column, col.data_type) %}
+                    {%- set col_type = dbt_utils.union_cast_type(col_type) %}
                     {%- set col_name = adapter.quote(col_name) if col_name in relation_columns[relation] else 'null' %}
                     cast({{ col_name }} as {{ col_type }}) as {{ col.quoted }} {% if not loop.last %},{% endif -%}
 


### PR DESCRIPTION
resolves #

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

We recently updated dbt-snowflake to return the collation on a column as part of the data_type as it will soon be required when altering a column's data type (if it's a string). Most of the time this is correct, unless you want to use that datatype in a `cast`. 

### Solution

Add a macro with a snowflake specific override to scrub `collation` from the datatype if it's present.

## Checklist
- [ ] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
