### PR TITLE
fix(recency): handle empty tables returning NULL

### DIFF
--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -37,5 +37,6 @@ select
 
 from recency
 where most_recent < {{ threshold }}
+   or most_recent is null
 
 {% endmacro %}


### PR DESCRIPTION
## Problem

When a table is completely empty, the `recency` test incorrectly passes instead of failing.

### Root Cause

When a table has no data, `MAX(field)` returns `NULL`. The current WHERE clause:

```sql
where most_recent < {{ threshold }}
```

With `most_recent = NULL`, the comparison `NULL < threshold` evaluates to `NULL` (not `TRUE`), so the WHERE clause filters out the row and returns zero rows — causing the test to pass.

### Reproduction

1. Create an empty table
2. Add a recency test to it
3. Run `dbt test` — the test passes even though there's no recent data

### Solution

Add `OR most_recent IS NULL` to the WHERE clause:

```sql
where most_recent < {{ threshold }}
   or most_recent is null
```

This ensures the test fails when:
- The table has data older than the threshold (`most_recent < threshold`)
- The table is completely empty (`most_recent IS NULL`)

### Testing

Verified locally with an empty Snowflake table that was previously passing the recency test incorrectly.