### PR TITLE
Migrate top-level test 'values' to 'arguments' (dbt0102)

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,10 @@
+Migrate top-level test `values` to `arguments` (dbt0102)
+
+This repo contains a small YAML-only change to the integration tests schema to
+wrap `values:` under `arguments:` for `accepted_values` tests.
+
+Rationale:
+- Addresses deprecation warnings about top-level test arguments (dbt0102).
+- No behavior change to the tests; simply adjusts to the newer expected schema.
+
+See the PR for the exact diff and additional context.

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -41,44 +41,51 @@ models:
       - name: count_a
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_b
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_c
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_d
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_e
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_f
         data_tests:
           - accepted_values:
-              values:
-                - '1'
+                  arguments:
+                    values:
+                      - '1'
 
       - name: count_g
         data_tests:
           - accepted_values:
-              values:
-                - '5'
+                  arguments:
+                    values:
+                      - '5'
 
   - name: test_get_column_values_where
     data_tests:


### PR DESCRIPTION
Migrate top-level test `values` to `arguments` (dbt0102)

Summary:
Wrap top-level `values:` under the `arguments:` key for `accepted_values` tests in the integration tests schema to address dbt deprecation `dbt0102` (deprecated top-level test arguments). This keeps test behaviour identical while conforming to the newer schema.

Changes:
- Move `values:` into `arguments:` for all `accepted_values` usages in `integration_tests/models/sql/schema.yml`.

Why:
- Prevents deprecation warnings and future breakage in dbt-fusion/dbt versions that enforce the new schema.

Testing:
- This is a static YAML-only change; no runtime logic modified. Tests remain the same and will continue to pass in CI.

Notes:
- Created by automated migration from the local repo that detected dbt0102 warnings. See PR for patch details.
