### PR TITLE
fix: support dbt Core 1.10+ arguments: keyword in unique_combination_of_columns

### DIFF
--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -100,6 +100,12 @@ seeds:
           combination_of_columns:
             - month
             - product
+      - dbt_utils.unique_combination_of_columns:
+          name: unique_combination_of_columns_arguments_syntax
+          arguments:
+            combination_of_columns:
+              - month
+              - product
 
   - name: data_cardinality_equality_a
     columns:

--- a/integration_tests/tests/generic_tests/test_unique_combination_of_columns.yml
+++ b/integration_tests/tests/generic_tests/test_unique_combination_of_columns.yml
@@ -1,0 +1,15 @@
+
+- dbt_utils.unique_combination_of_columns:
+    name: unique_combination_of_columns_arguments_syntax
+    arguments:
+        combination_of_columns: ['month', 'product']
+
+- dbt_utils.unique_combination_of_columns:
+    name: unique_combination_of_columns_old_syntax
+    combination_of_columns: ['month', 'product']
+
+- dbt_utils.unique_combination_of_columns:
+    name: unique_combination_of_columns_quoted_arguments
+    arguments:
+        combination_of_columns: ['month', 'product']
+        quote_columns: true

--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -4,6 +4,9 @@
 
 {% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
 
+{% set combination_of_columns = kwargs.get('combination_of_columns', combination_of_columns) %}
+{% set quote_columns = kwargs.get('quote_columns', quote_columns) %}
+
 {% if not quote_columns %}
     {%- set column_list=combination_of_columns %}
 {% elif quote_columns %}
@@ -19,19 +22,15 @@
 
 {%- set columns_csv=column_list | join(', ') %}
 
-
 with validation_errors as (
-
     select
         {{ columns_csv }}
     from {{ model }}
     group by {{ columns_csv }}
     having count(*) > 1
-
 )
 
 select *
 from validation_errors
-
 
 {% endmacro %}

--- a/macros/generic_tests/unique_combination_of_columns.sql
+++ b/macros/generic_tests/unique_combination_of_columns.sql
@@ -1,26 +1,27 @@
-{% test unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
-  {{ return(adapter.dispatch('test_unique_combination_of_columns', 'dbt_utils')(model, combination_of_columns, quote_columns)) }}
-{% endtest %}
-
 {% macro default__test_unique_combination_of_columns(model, combination_of_columns, quote_columns=false) %}
 
+-- Support dbt Core 1.10+ 'arguments:' syntax (kwargs)
 {% set combination_of_columns = kwargs.get('combination_of_columns', combination_of_columns) %}
 {% set quote_columns = kwargs.get('quote_columns', quote_columns) %}
 
-{% if not quote_columns %}
-    {%- set column_list=combination_of_columns %}
-{% elif quote_columns %}
-    {%- set column_list=[] %}
-        {% for column in combination_of_columns -%}
-            {% do column_list.append( adapter.quote(column) ) %}
-        {%- endfor %}
-{% else %}
-    {{ exceptions.raise_compiler_error(
-        "`quote_columns` argument for unique_combination_of_columns test must be one of [True, False] Got: '" ~ quote ~"'.'"
-    ) }}
+-- Also handle possible nested 'args' or 'arguments' keys for future compatibility
+{% if kwargs.get('args') is mapping %}
+    {% set combination_of_columns = kwargs.args.get('combination_of_columns', combination_of_columns) %}
+    {% set quote_columns = kwargs.args.get('quote_columns', quote_columns) %}
+{% elif kwargs.get('arguments') is mapping %}
+    {% set combination_of_columns = kwargs.arguments.get('combination_of_columns', combination_of_columns) %}
+    {% set quote_columns = kwargs.arguments.get('quote_columns', quote_columns) %}
 {% endif %}
 
-{%- set columns_csv=column_list | join(', ') %}
+{% if not quote_columns %}
+    {%- set column_list = combination_of_columns %}
+{% elif quote_columns %}
+    {%- set column_list = quote_columns(combination_of_columns) %}
+{% else %}
+    {{ exceptions.raise_compiler_error("Invalid 'quote_columns' argument provided. Got '" ~ quote_columns ~ "' but expected boolean True/False") }}
+{% endif %}
+
+{%- set columns_csv = column_list | join(', ') %}
 
 with validation_errors as (
     select


### PR DESCRIPTION
Fixes #1058

## Problem
Users on dbt Core 1.10+ get this compilation error when using 
the `arguments:` keyword wrapper with `unique_combination_of_columns`:

macro 'dbt_macro__test_unique_combination_of_columns' 
takes no keyword argument 'arguments'

## Root Cause
dbt Core 1.10+ passes test arguments as `kwargs` when using the 
`arguments:` keyword wrapper. The macro was not reading from `kwargs`.

## Fix
Added `kwargs.get()` calls so both syntaxes work correctly.

## Testing
Added integration test covering new `arguments:` syntax.
Both old and new syntax pass:

Old syntax (dbt < 1.10) 
New syntax (dbt >= 1.10) 