### PR TITLE
fix(get_url_parameter): only match complete parameter names

### DIFF
--- a/integration_tests/tests/web/test_get_url_parameter_substring.sql
+++ b/integration_tests/tests/web/test_get_url_parameter_substring.sql
@@ -1,0 +1,115 @@
+-- Regression tests for https://github.com/dbt-labs/dbt-utils/issues/980
+--
+-- `get_url_parameter` must only match a parameter when the search token
+-- appears as a complete parameter name — not when the token happens to be
+-- a suffix of a different parameter name. The cases below all used to
+-- return the matched substring's value rather than NULL.
+
+with cases as (
+
+    select
+        'http://example.com/?msg=hello'                               as url,
+        'g'                                                           as param,
+        cast(null as {{ dbt.type_string() }})                         as expected
+
+    union all
+
+    select
+        'http://example.com/?sku=EXAMPLE_SKU&u=https%3A%2F%2Fx.com',
+        'ku',
+        cast(null as {{ dbt.type_string() }})
+
+    union all
+
+    -- Legitimate short-name parameter matches must still resolve correctly.
+    select
+        'http://example.com/?m=first_value&s=second_value',
+        'm',
+        'first_value'
+
+    union all
+
+    select
+        'http://example.com/?m=first_value&s=second_value',
+        's',
+        'second_value'
+
+    union all
+
+    -- Existing behaviour must be preserved.
+    select
+        'http://example.com/?utm_medium=organic&utm_source=github',
+        'utm_source',
+        'github'
+
+    union all
+
+    select
+        'http://example.com/?utm_medium=organic&utm_source=github',
+        'utm_medium',
+        'organic'
+
+),
+
+comparisons as (
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 'g') }}           as actual,
+        case when param = 'g' then expected end                 as expected,
+        param
+    from cases
+    where param = 'g'
+
+    union all
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 'ku') }}          as actual,
+        case when param = 'ku' then expected end                as expected,
+        param
+    from cases
+    where param = 'ku'
+
+    union all
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 'm') }}           as actual,
+        case when param = 'm' then expected end                 as expected,
+        param
+    from cases
+    where param = 'm'
+
+    union all
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 's') }}           as actual,
+        case when param = 's' then expected end                 as expected,
+        param
+    from cases
+    where param = 's'
+
+    union all
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 'utm_source') }}  as actual,
+        case when param = 'utm_source' then expected end        as expected,
+        param
+    from cases
+    where param = 'utm_source'
+
+    union all
+
+    select
+        {{ dbt_utils.get_url_parameter('url', 'utm_medium') }}  as actual,
+        case when param = 'utm_medium' then expected end        as expected,
+        param
+    from cases
+    where param = 'utm_medium'
+
+)
+
+-- A row is a failure if actual and expected disagree, treating NULLs as equal.
+select *
+from comparisons
+where
+    (actual is null) <> (expected is null)
+    or coalesce(actual, '') <> coalesce(expected, '')

--- a/macros/web/get_url_parameter.sql
+++ b/macros/web/get_url_parameter.sql
@@ -4,9 +4,19 @@
 
 {% macro default__get_url_parameter(field, url_parameter) -%}
 
-{%- set formatted_url_parameter = "'" + url_parameter + "='" -%}
+{#-
+    Normalize the query string so every parameter is preceded by `&`, then split on
+    `&<url_parameter>=`. Requiring the leading `&` in the search token prevents false
+    matches against parameters whose names merely *end* with `url_parameter`
+    (e.g. searching for `g` inside `...&msg=...`).
+    See: https://github.com/dbt-labs/dbt-utils/issues/980
+-#}
 
-{%- set split = dbt.split_part(dbt.split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
+{%- set formatted_url_parameter = "'&" + url_parameter + "='" -%}
+
+{%- set normalized_field = dbt.concat(["'&'", dbt.replace(field, "'?'", "'&'")]) -%}
+
+{%- set split = dbt.split_part(dbt.split_part(normalized_field, formatted_url_parameter, 2), "'&'", 1) -%}
 
 nullif({{ split }},'')
 


### PR DESCRIPTION
resolves #980
(also resolves the duplicate report in #1014)

### Problem

`dbt_utils.get_url_parameter` silently returns the wrong value when the
requested parameter name is a *suffix* of a different parameter name that
actually exists in the URL.

The macro splits the URL on `<url_parameter>=`, so any parameter whose name
ends with the search token matches. Two examples from the linked issues:

- `get_url_parameter('url', 'g')` against `http://example.com/?msg=myvalue`
  returns `myvalue` (because `msg=` contains `g=`).
- `get_url_parameter('url', 'ku')` against
  `http://example.com/?sku=EXAMPLE_SKU&u=...` returns `EXAMPLE_SKU`.

The expected behaviour is to return `NULL` whenever the URL does not contain
a parameter whose full name matches the search token.

### Solution

Normalize the URL so every parameter is preceded by `&`, then split on
`&<url_parameter>=`. Requiring the leading `&` in the search token means
only complete parameter names match.

The normalization uses cross-database primitives that `dbt-utils` already
relies on elsewhere (`dbt.replace`, `dbt.concat`, `dbt.split_part`), so the
change stays dispatch-friendly and adapter-neutral:

```jinja
{%- set formatted_url_parameter = "'&" + url_parameter + "='" -%}
{%- set normalized_field = dbt.concat(["'&'", dbt.replace(field, "'?'", "'&'")]) -%}
{%- set split = dbt.split_part(dbt.split_part(normalized_field, formatted_url_parameter, 2), "'&'", 1) -%}
```

Alternatives considered:

- **Regex-based extraction** (`regexp_substr` / `regexp_match`): cleanest
  semantically, but each warehouse uses a different regex function and
  argument order, so it would require per-adapter dispatch. Sticking with
  `split_part` / `replace` / `concat` keeps the macro single-implementation.
- **Prepend only inside the search token** (`&<param>=`) without also
  prepending to `field`: fails when the requested parameter is the first
  one in the query string after normalization, because there is no leading
  `&` in the URL itself.

### Tests

Added a singular test at
`integration_tests/tests/web/test_get_url_parameter_substring.sql` that
covers both regression cases and the legitimate short-name cases:

- Short-name suffix regressions (`g` against `?msg=...`, `ku` against
  `?sku=...`) must return `NULL`.
- Single-character parameter names (`?m=...`, `?s=...`) must still resolve
  correctly.
- Pre-existing behaviour (`utm_medium`, `utm_source`) is unchanged.

The test compares `actual` and `expected` with NULL-safe equality so
`NULL = NULL` is treated as a pass rather than "unknown" (which would
otherwise let regressions slip through the existing `!=` comparison).

Verified locally against `dbt-postgres` (`make setup-db` + `dbt build`):

- The new test **fails** on `main` with 2 failing rows (confirming it
  exercises the bug).
- The new test **passes** on this branch.
- Existing `test_urls`, `test_url_host`, and `test_url_path` tests all
  still pass.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues/980) which has been triaged and accepted for development.
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable) — not applicable; public API unchanged
