### PR TITLE
Reduce INFORMATION_SCHEMA calls in BigQuery get_tables_by_pattern_sql

### DIFF
--- a/macros/sql/get_tables_by_pattern_sql.sql
+++ b/macros/sql/get_tables_by_pattern_sql.sql
@@ -45,6 +45,25 @@
 
 {% macro bigquery__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
 
+    {# When `target.location` is set, the region-qualified INFORMATION_SCHEMA.TABLES
+       exposes `table_schema` directly. That collapses a SCHEMATA lookup plus a
+       per-dataset UNION ALL into one query. Falls back to the original
+       SCHEMATA + iterate path when no location is configured. #}
+    {% if '%' in schema_pattern and target.location %}
+        {% set sql %}
+            select distinct
+                table_schema,
+                table_name,
+                {{ dbt_utils.get_table_types_sql() }}
+            from {{ adapter.quote(database) }}.`region-{{ target.location | lower }}`.INFORMATION_SCHEMA.TABLES
+            where lower(table_schema) like lower('{{ schema_pattern }}')
+                and lower(table_name) like lower('{{ table_pattern }}')
+                and lower(table_name) not like lower('{{ exclude }}')
+        {% endset %}
+
+        {{ return(sql) }}
+    {% endif %}
+
     {% if '%' in schema_pattern %}
         {% set schemata=dbt_utils._bigquery__get_matching_schemata(schema_pattern, database) %}
     {% else %}


### PR DESCRIPTION
### Problem

On BigQuery, `dbt_utils.get_relations_by_pattern` (via `get_tables_by_pattern_sql`) runs two kinds of `INFORMATION_SCHEMA` queries whenever the `schema_pattern` contains `%`:

1. An `INFORMATION_SCHEMA.SCHEMATA` lookup to enumerate matching datasets.
2. A `UNION ALL` of one dataset-scoped `INFORMATION_SCHEMA.TABLES` query per match.

This is more work than necessary. The region-qualified `` `project`.`region-X`.INFORMATION_SCHEMA.TABLES `` view already exposes `table_schema`, so the schema match can happen inside the same query as the table match.

### Solution

When `target.location` is set, query the region-qualified `INFORMATION_SCHEMA.TABLES` view once and filter `table_schema` directly. The `SCHEMATA` call and the `UNION ALL` go away. 

The existing `SCHEMATA` + iterate path is kept as a fallback for profiles without a configured location, so behaviour is unchanged for those users. The single-schema (no `%`) path is also unchanged. Since BigQuery is highly dependent on region, I assume most users set the target.location value. The previous version did not allow region override so it is still an improvement over that. I think we might even remove the fallback, and allow it to error instead.

### Note on CI coverage

`integration_tests/profiles.yml` doesn't set `location`, so the existing `test_get_relations_by_pattern` model exercises the fallback path, not the new one. Happy to add `location: US` to the integration profile if maintainers want the fast path covered in CI.

## Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
