### PR TITLE
Add BigQuery-native union_relations using FULL OUTER UNION ALL BY NAME

### DIFF
--- a/integration_tests/data/sql/data_union_exclude_expected.csv
+++ b/integration_tests/data/sql/data_union_exclude_expected.csv
@@ -2,5 +2,5 @@ id,favorite_color,favorite_number
 1,,pi
 2,,e
 3,,4
-1,"green",7
-2,"pink",13
+1,"green",seven
+2,"pink",thirteen

--- a/integration_tests/data/sql/data_union_expected.csv
+++ b/integration_tests/data/sql/data_union_expected.csv
@@ -2,5 +2,5 @@ id,name,favorite_color,favorite_number
 1,"drew",,pi
 2,"bob",,e
 3,"alice",,4
-1,,"green",7
-2,,"pink",13
+1,,"green",seven
+2,,"pink",thirteen

--- a/integration_tests/data/sql/data_union_table_2.csv
+++ b/integration_tests/data/sql/data_union_table_2.csv
@@ -1,3 +1,3 @@
 id,favorite_color,favorite_number
-1,green,7
-2,pink,13
+1,green,seven
+2,pink,thirteen

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -18,6 +18,11 @@
 
     {%- set column_override = column_override if column_override is not none else {} -%}
 
+    {%- for relation in relations -%}
+        {%- do dbt_utils._is_relation(relation, 'union_relations') -%}
+        {%- do dbt_utils._is_ephemeral(relation, 'union_relations') -%}
+    {%- endfor -%}
+
     select *
         {%- if exclude %} except ({{ exclude | join(', ') }}){% endif -%}
         {%- if column_override %} replace (
@@ -27,9 +32,6 @@
         ){% endif %}
     from (
         {%- for relation in relations %}
-
-            {%- do dbt_utils._is_relation(relation, 'union_relations') -%}
-            {%- do dbt_utils._is_ephemeral(relation, 'union_relations') -%}
 
             select
                 {%- if source_column_name is not none %}

--- a/macros/sql/union.sql
+++ b/macros/sql/union.sql
@@ -2,6 +2,52 @@
     {{ return(adapter.dispatch('union_relations', 'dbt_utils')(relations, column_override, include, exclude, source_column_name, where)) }}
 {% endmacro %}
 
+{%- macro bigquery__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
+
+    {%- if exclude and include -%}
+        {{ exceptions.raise_compiler_error("Both an exclude and include list were provided to the `union` macro. Only one is allowed") }}
+    {%- endif -%}
+
+    {#-- BigQuery has no native projector that names columns to keep, so `include`
+         still needs column enumeration. Fall back to the default path for that case. --#}
+    {%- if include -%}
+        {{ return(dbt_utils.default__union_relations(relations, column_override, include, exclude, source_column_name, where)) }}
+    {%- endif -%}
+
+    {%- if not execute -%}{{ return('') }}{%- endif -%}
+
+    {%- set column_override = column_override if column_override is not none else {} -%}
+
+    select *
+        {%- if exclude %} except ({{ exclude | join(', ') }}){% endif -%}
+        {%- if column_override %} replace (
+            {%- for col, type in column_override.items() %}
+                cast({{ adapter.quote(col) }} as {{ type }}) as {{ adapter.quote(col) }}{% if not loop.last %},{% endif %}
+            {%- endfor %}
+        ){% endif %}
+    from (
+        {%- for relation in relations %}
+
+            {%- do dbt_utils._is_relation(relation, 'union_relations') -%}
+            {%- do dbt_utils._is_ephemeral(relation, 'union_relations') -%}
+
+            select
+                {%- if source_column_name is not none %}
+                cast({{ dbt.string_literal(relation.render()) }} as {{ dbt.type_string() }}) as {{ source_column_name }},
+                {%- endif %}
+                *
+            from {{ relation }}
+            {%- if where %}
+            where {{ where }}
+            {%- endif %}
+
+            {% if not loop.last %}full outer union all by name{% endif %}
+
+        {%- endfor %}
+    )
+
+{%- endmacro -%}
+
 {%- macro default__union_relations(relations, column_override=none, include=[], exclude=[], source_column_name='_dbt_source_relation', where=none) -%}
 
     {%- if exclude and include -%}


### PR DESCRIPTION
### Problem

On BigQuery, `dbt_utils.union_relations` calls `adapter.get_columns_in_relation` on every input relation, which on the BigQuery adapter is backed by an `INFORMATION_SCHEMA.COLUMNS` query per relation. It then emits a fully-enumerated `SELECT` per relation: every column from the cross-relation superset listed with explicit `cast(... as type)` plus `cast(null as type)` padding for columns missing from that relation. For wide tables or many relations this produces hundreds of lines of generated SQL.

BigQuery natively supports both halves of what the macro is doing by hand:

- `FULL OUTER UNION ALL BY NAME` matches columns by name across queries and fills missing columns with NULL.
- `SELECT * EXCEPT (...)` and `SELECT * REPLACE (cast(col as type) AS col)` cover `exclude` and `column_override` without enumerating columns.

_But most importantly_: it cuts out the need to call INFORMATION_SCHEMA, which means one less roundtrip to BigQuery.

### Solution

Add a `bigquery__union_relations` dispatch that uses these features directly. The new path **issues zero `INFORMATION_SCHEMA` queries** — no per-relation column lookup is needed at all, since `BY NAME` resolves the schema match at query time. Generated SQL collapses from N enumerated `SELECT` lists to one `*`-projection per relation joined by `FULL OUTER UNION ALL BY NAME`, with `EXCEPT`/`REPLACE` wrapped around the result for `exclude` and `column_override`.

Example output for `union_relations([a, b, c])`:

```sql
select * from (
    select cast('a' as string) as _dbt_source_relation, * from a
    full outer union all by name
    select cast('b' as string) as _dbt_source_relation, * from b
    full outer union all by name
    select cast('c' as string) as _dbt_source_relation, * from c
)
```

The `include` path falls back to the default implementation, since BigQuery has no native syntax for projecting a named subset of columns — column enumeration (and the `INFORMATION_SCHEMA` calls) are unavoidable there.

### Behaviour differences worth flagging

- **`column_override` referencing a column that exists in no relation now errors.** The default macro silently drops such overrides; BigQuery's `REPLACE` requires the column to exist in the projection. This seems more useful — a missing-column override is almost always a typo — but it is a tightening.
- **Cross-relation type coercion uses BigQuery's supertype rules** instead of "first relation wins". E.g. `INT64` in one relation and `FLOAT64` in another widen to `FLOAT64` rather than truncating to whichever was seen first. Strictly more correct, but technically different behaviour.
- **"No columns found" compiler error** is not raised in the fast path, since columns are no longer enumerated upfront. If all inputs are empty the union just returns no rows.

## Checklist
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the README.md (if applicable)
