### PR TITLE
fix: alias filler column in expression_is_true for strict-alias dialects

### DIFF
--- a/integration_tests/tests/generic/expression_is_true_subquery_alias.sql
+++ b/integration_tests/tests/generic/expression_is_true_subquery_alias.sql
@@ -1,0 +1,33 @@
+{#
+    Validates that test_expression_is_true emits a column alias for its
+    placeholder column so that the rendered SQL is valid inside a subquery
+    on strict-alias dialects (e.g. T-SQL / Microsoft Fabric Data Warehouse,
+    some Spark configurations). Previously the macro emitted `select 1
+    from ...`, which compiles standalone but fails with errors like
+    "Missing column specification" (Snowflake, historical) or "no column
+    name was specified for column 1 of 'sub'" (T-SQL) once any caller wraps
+    the result in another SELECT. See dbt-labs/dbt-utils#822.
+
+    This test compiles the macro for a model with column_name unset and
+    wraps the rendered SQL in an outer SELECT. If the inner SELECT did not
+    alias its placeholder column, the wrapping outer SELECT would fail to
+    compile on strict-alias dialects.
+#}
+
+-- depends_on: {{ ref('data_test_expression_is_true') }}
+
+{% set inner_sql = dbt_utils.test_expression_is_true(
+    model=ref('data_test_expression_is_true'),
+    expression='col_a + col_b = 1',
+    column_name=none
+) %}
+
+with wrapped as (
+    select * from (
+        {{ inner_sql }}
+    ) as sub
+)
+
+select *
+from wrapped
+where 1 = 0

--- a/macros/generic_tests/expression_is_true.sql
+++ b/macros/generic_tests/expression_is_true.sql
@@ -4,7 +4,7 @@
 
 {% macro default__test_expression_is_true(model, expression, column_name) %}
 
-{% set column_list = '*' if should_store_failures() else "1" %}
+{% set column_list = '*' if should_store_failures() else "1 as filler_column" %}
 
 select
     {{ column_list }}


### PR DESCRIPTION
## Problem

`default__test_expression_is_true` emits an unnamed literal `1` as its placeholder column when `should_store_failures()` is false:

https://github.com/dbt-labs/dbt-utils/blob/main/macros/generic_tests/expression_is_true.sql#L7

```jinja
{% set column_list = '*' if should_store_failures() else "1" %}
```

This compiles fine standalone, but as soon as anything wraps the rendered SQL in a subquery, strict-alias dialects reject it because the inner column has no name. Concrete failure modes:

- **T-SQL (Microsoft SQL Server / Fabric Data Warehouse):** `Msg 8155, Level 16, State 2: No column name was specified for column 1 of 'sub'.`
- **Snowflake (historical):** `SQL compilation error: Missing column specification` — reported in #822, closed as Stale without a fix.
- **Some Spark configurations** that enforce strict aliasing in nested SELECTs.

Subquery wrapping is not exotic — it happens whenever a downstream macro composes generic tests, when stored-failures alternates with non-stored-failures, or when users manually wrap the test (for example to feed it into a custom monitoring model).

## Fix

One-line change: name the placeholder column.

```diff
-{% set column_list = '*' if should_store_failures() else "1" %}
+{% set column_list = '*' if should_store_failures() else "1 as filler_column" %}
```

The name `filler_column` matches the convention already used in `at_least_one`, which carries an explicit comment about this same T-SQL constraint:

https://github.com/dbt-labs/dbt-utils/blob/main/macros/generic_tests/at_least_one.sql#L36-L38

```jinja
{# In TSQL, subquery aggregate columns need aliases #}
{# thus: a filler col name, 'filler_column' #}
count({{ column_name }}) as filler_column
```

So the fix is consistent with how the project already solves the same class of problem in a sibling test.

## Impact

- **Helps:** every strict-alias dialect (T-SQL / Fabric, Snowflake under the configurations from #822, some Spark setups, anyone wrapping the test in a subquery).
- **Breaks:** nothing. `select 1 as filler_column from x` is valid SQL on PostgreSQL, Snowflake, BigQuery, Redshift, Databricks, Spark, T-SQL, and DuckDB. The test still returns the same row count to dbt, so pass/fail semantics are unchanged.

## Out of scope

This PR does **not** reintroduce the `condition` argument removed in #700. That decision stands; this is purely a portability fix for the existing macro.

## Evidence

- Stale upstream bug report: dbt-labs/dbt-utils#822
- Existing downstream workaround in `dbt-fabric`: https://github.com/sdebruyn/dbt-fabric/blob/main/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/generic_tests/expression_is_true.sql — patches exactly the same line to `"1 as col"`. With this PR, that override can be deleted.

## Test plan

- [x] Added `integration_tests/tests/generic/expression_is_true_subquery_alias.sql`, which compiles the macro and wraps its output in an outer SELECT. Without the fix this would have failed to compile on strict-alias dialects.
- [ ] Existing `data_test_expression_is_true` schema tests continue to pass on the supported adapter matrix.