### PR TITLE
fix: alias derived-table source in sequential_values for strict-alias dialects

### DIFF
--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -261,3 +261,13 @@ models:
           compare_model: ref('data_test_equality_a')
           exclude_columns:
             - col_c
+
+  - name: test_sequential_values_ephemeral
+    columns:
+      - name: my_even_sequence
+        data_tests:
+          - dbt_utils.sequential_values:
+              interval: 2
+          - dbt_utils.sequential_values:
+              interval: 2
+              group_by_columns: ['col_a']

--- a/integration_tests/models/generic_tests/test_sequential_values_ephemeral.sql
+++ b/integration_tests/models/generic_tests/test_sequential_values_ephemeral.sql
@@ -1,0 +1,7 @@
+{{ config(materialized='ephemeral') }}
+
+select
+    col_a,
+    my_even_sequence
+
+from {{ ref('data_test_sequential_values') }}

--- a/macros/generic_tests/sequential_values.sql
+++ b/macros/generic_tests/sequential_values.sql
@@ -22,7 +22,7 @@ with windowed as (
             {{partition_gb_cols}}
             order by {{ column_name }}
         ) as {{ previous_column_name }}
-    from {{ model }}
+    from {{ model }} as _dbt_utils_sequential_values_source
 ),
 
 validation_errors as (


### PR DESCRIPTION
## Summary

The `sequential_values` generic test renders `from {{ model }}` inside its `windowed` CTE without an alias on the source. When the caller is an **ephemeral model**, dbt inlines the `ref` as a subquery, which produces an unaliased derived table in the CTE.

Permissive dialects (Postgres, BigQuery, Snowflake, Redshift, DuckDB) accept this, but several SQL engines reject an unaliased derived table inside a CTE:

- **T-SQL** (Microsoft SQL Server, Microsoft Fabric Data Warehouse): `Incorrect syntax near ','. Expecting AS, ID, QUOTED_ID...` / `Derived table must have an alias.`
- **Spark** (some configurations and engine variants, depending on `spark.sql.parser.*` flags)

This is the same class of issue solved elsewhere in `dbt-utils` (e.g. `at_least_one` wraps its source in a CTE named `pruned_rows`). For `sequential_values`, the minimal fix is a one-line alias on the source.

## Change

One line in `macros/generic_tests/sequential_values.sql`:

```diff
-    from {{ model }}
+    from {{ model }} as _dbt_utils_sequential_values_source
```

The alias is intentionally long and macro-namespaced to avoid colliding with user column names or aliases in the rendered SQL.

## Why this is dialect-agnostic

An explicit alias on a CTE source is valid SQL in every supported adapter. The permissive dialects already accept the unaliased form, so they keep working; the strict dialects start working. No adapter overrides are needed.

## Test

Added an integration test under `integration_tests/models/generic_tests/`:

- `test_sequential_values_ephemeral.sql`: a `materialized='ephemeral'` model that selects from the existing `data_test_sequential_values` seed.
- `schema.yml`: applies `dbt_utils.sequential_values` to the ephemeral model with both the plain interval form and the `group_by_columns` form.

The existing seed-level tests in `data/schema_tests/schema.yml` exercise `sequential_values` against a non-ephemeral seed, which is exactly the path that did *not* trigger the bug. The new ephemeral test covers the failing path.

## Evidence

A real-world adapter (`dbt-fabric`) has been carrying a downstream override of this macro with a `required_alias_for_tsql` patch for exactly this reason. See [the override in `sdebruyn/dbt-fabric`](https://github.com/sdebruyn/dbt-fabric/blob/main/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/schema_tests/sequential_values.sql) (the `from {{ model }} required_alias_for_tsql` line). Fixing this upstream removes the need for that override and helps every current and future strict-alias adapter.

## Scope

This PR addresses only the alias problem. Other downstream-only differences (e.g. `dbt_utils.slugify` not being adapter-agnostic in all fork builds) are out of scope.