### PR TITLE
fix: generate_surrogate_key handles single-field lists without concat

### DIFF
--- a/integration_tests/data/sql/data_generate_surrogate_key_single_field.csv
+++ b/integration_tests/data/sql/data_generate_surrogate_key_single_field.csv
@@ -1,0 +1,4 @@
+input_value,expected_key
+a,0cc175b9c0f1b6a831c399e269772661
+b,92eb5ffee6ae2fec3ad71c777531578f
+,f14cc5cdce0420f4a5a6b6d9d7b85f39

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -204,6 +204,12 @@ models:
           actual: actual_all_columns_list
           expected: expected_all_columns
 
+  - name: test_generate_surrogate_key_single_field
+    data_tests:
+      - assert_equal:
+          actual: actual_key
+          expected: expected_key
+
   - name: test_union
     data_tests:
       - dbt_utils.equality:

--- a/integration_tests/models/sql/test_generate_surrogate_key_single_field.sql
+++ b/integration_tests/models/sql/test_generate_surrogate_key_single_field.sql
@@ -1,0 +1,12 @@
+
+with data as (
+
+    select * from {{ ref('data_generate_surrogate_key_single_field') }}
+
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['input_value']) }} as actual_key,
+    expected_key
+
+from data

--- a/macros/sql/generate_surrogate_key.sql
+++ b/macros/sql/generate_surrogate_key.sql
@@ -24,6 +24,10 @@
 
 {%- endfor -%}
 
-{{ dbt.hash(dbt.concat(fields)) }}
+{%- if fields|length > 1 -%}
+    {{ dbt.hash(dbt.concat(fields)) }}
+{%- else -%}
+    {{ dbt.hash(fields[0]) }}
+{%- endif -%}
 
 {%- endmacro -%}


### PR DESCRIPTION
## Problem

`generate_surrogate_key(['id'])` compiles its final expression to `dbt.hash(dbt.concat([coalesce(cast(id as ...), '...')])`. On adapters whose `default__concat` override uses the function form `CONCAT(x, y, ...)` instead of the `||` operator (e.g. SQL Server, Microsoft Fabric T-SQL), the resulting `CONCAT(x)` raises:

> The concat function requires 2 to 254 arguments.

Reported and reproduced in #827 against both `dbt-sqlserver` and `dbt-fabric`. The issue was closed as Stale without a fix.

This makes `generate_surrogate_key` — one of the most widely used dbt-utils macros — unusable with a one-field list on T-SQL-family adapters, forcing every downstream user to write a workaround or vendor the macro.

## Fix

Guard the final hash expression so single-field lists skip `concat` entirely:

```jinja
{%- if fields|length > 1 -%}
    {{ dbt.hash(dbt.concat(fields)) }}
{%- else -%}
    {{ dbt.hash(fields[0]) }}
{%- endif -%}
```

The multi-field path is unchanged. For adapters using the default operator-based `concat` (`a || b || ...`), `concat([x])` compiles to `x`, so `dbt.hash(dbt.concat([x]))` and `dbt.hash(x)` are byte-identical SQL — no behavior change for any existing user.

## Why upstream

This is an adapter-agnostic bug. Any adapter that overrides `default__concat` with the SQL `CONCAT()` function form (which is the natural choice on T-SQL and several other dialects) hits this. Fixing it in dbt-utils unblocks every such adapter at once without requiring each one to ship its own override of `generate_surrogate_key`.

## Related parallel work

A complementary structural fix is being prepared for `dbt-adapters` to make `default__concat` itself tolerate a single argument. The dbt-utils fix is faster to ship to end users and works regardless of the installed dbt-adapters version.

## Test

Adds an integration test (`test_generate_surrogate_key_single_field`) that calls `generate_surrogate_key(['input_value'])` against a seed with populated and NULL inputs, and asserts the resulting MD5 against expected hashes (including the `_dbt_utils_surrogate_key_null_` sentinel for NULL).

## Reference

A targeted override of this macro is currently shipped in [dbt-fabric](https://github.com/sdebruyn/dbt-fabric/blob/main/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/sql/generate_surrogate_key.sql) as a workaround for the same root cause. With this PR merged, that override can be removed.

Closes #827.