### PR TITLE
fix: NULL-safe diff calculation in equal_rowcount and fewer_rows_than

### DIFF
--- a/integration_tests/data/schema_tests/data_test_equal_rowcount_groups_a.csv
+++ b/integration_tests/data/schema_tests/data_test_equal_rowcount_groups_a.csv
@@ -1,0 +1,9 @@
+group_col,field
+x,1
+x,2
+x,3
+y,1
+y,2
+y,3
+y,4
+y,5

--- a/integration_tests/data/schema_tests/data_test_equal_rowcount_groups_b.csv
+++ b/integration_tests/data/schema_tests/data_test_equal_rowcount_groups_b.csv
@@ -1,0 +1,6 @@
+group_col,field
+x,1
+x,2
+x,3
+z,1
+z,2

--- a/integration_tests/models/generic_tests/schema.yml
+++ b/integration_tests/models/generic_tests/schema.yml
@@ -238,6 +238,18 @@ models:
           compare_model: ref('test_equal_rowcount')
           group_by_columns: ['field']
 
+  - name: test_equal_rowcount_groups
+    data_tests:
+      # Regression test for NULL handling with group_by_columns when groups are
+      # present in one model but not the other. After the full join, count_a or
+      # count_b is NULL for unmatched groups; without coalesce, diff_count
+      # collapses to NULL and the test silently passes despite a true mismatch.
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('data_test_equal_rowcount_groups_b')
+          group_by_columns: ['group_col']
+          error_if: "<1" #sneaky way to ensure that the test is returning failing rows
+          warn_if: "<0"
+
   - name: test_equal_column_subset
     data_tests:
       - dbt_utils.equality:
@@ -254,6 +266,18 @@ models:
       - dbt_utils.fewer_rows_than:
           compare_model: ref('data_test_fewer_rows_than_table_2')
           group_by_columns: ['col_a']
+
+  - name: test_fewer_rows_than_groups
+    data_tests:
+      # Regression test for NULL handling with group_by_columns when groups are
+      # present in one model but not the other. After the full join, count_our_model
+      # or count_comparison_model is NULL for unmatched groups; without coalesce,
+      # the case expression evaluates to NULL and row_count_delta is lost.
+      - dbt_utils.fewer_rows_than:
+          compare_model: ref('data_test_equal_rowcount_groups_b')
+          group_by_columns: ['group_col']
+          error_if: "<1" #sneaky way to ensure that the test is returning failing rows
+          warn_if: "<0"
 
   - name: equality_less_columns
     data_tests:

--- a/integration_tests/models/generic_tests/test_equal_rowcount_groups.sql
+++ b/integration_tests/models/generic_tests/test_equal_rowcount_groups.sql
@@ -1,0 +1,9 @@
+with data as (
+
+    select * from {{ ref('data_test_equal_rowcount_groups_a') }}
+
+)
+
+select
+    group_col, field
+from data

--- a/integration_tests/models/generic_tests/test_fewer_rows_than_groups.sql
+++ b/integration_tests/models/generic_tests/test_fewer_rows_than_groups.sql
@@ -1,0 +1,9 @@
+with data as (
+
+    select * from {{ ref('data_test_equal_rowcount_groups_a') }}
+
+)
+
+select
+    group_col, field
+from data

--- a/macros/generic_tests/equal_rowcount.sql
+++ b/macros/generic_tests/equal_rowcount.sql
@@ -58,9 +58,9 @@ final as (
           b.{{c}} as {{c}}_b,
         {% endfor %}
 
-        count_a,
-        count_b,
-        abs(count_a - count_b) as diff_count
+        coalesce(count_a, 0) as count_a,
+        coalesce(count_b, 0) as count_b,
+        abs(coalesce(count_a, 0) - coalesce(count_b, 0)) as diff_count
 
     from a
     full join b

--- a/macros/generic_tests/fewer_rows_than.sql
+++ b/macros/generic_tests/fewer_rows_than.sql
@@ -65,9 +65,9 @@ final as (
     select *,
         case
             -- fail the test if we have more rows than the reference model and return the row count delta
-            when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)
+            when coalesce(count_our_model, 0) > coalesce(count_comparison_model, 0) then (coalesce(count_our_model, 0) - coalesce(count_comparison_model, 0))
             -- fail the test if they are the same number
-            when count_our_model = count_comparison_model then 1
+            when coalesce(count_our_model, 0) = coalesce(count_comparison_model, 0) then 1
             -- pass the test if the delta is positive (i.e. return the number 0)
             else 0
     end as row_count_delta


### PR DESCRIPTION
## Problem

When `dbt_utils.equal_rowcount` and `dbt_utils.fewer_rows_than` are invoked with `group_by_columns`, the macros build per-group counts in CTEs `a` and `b` and then `full join` them on the group key. If a group exists in only one of the two models, the side without the group produces `NULL` for its count after the join. Subsequent arithmetic and comparisons then collapse to `NULL`, which silently hides the failure.

### `equal_rowcount`

```sql
abs(count_a - count_b) as diff_count
```

For an unmatched group (`count_a = 5`, `count_b = NULL`):
- `count_a - count_b` -> `NULL`
- `abs(NULL)` -> `NULL`
- `diff_count` for that row is `NULL`

The configured `fail_calc` is `sum(coalesce(diff_count, 0))`, so the row contributes `0` to the failure count. A genuinely unequal pair of models passes the test.

### `fewer_rows_than`

```sql
case
    when count_our_model > count_comparison_model then (count_our_model - count_comparison_model)
    when count_our_model = count_comparison_model then 1
    else 0
end as row_count_delta
```

For an unmatched group (`count_our_model = 5`, `count_comparison_model = NULL`):
- `5 > NULL` -> `NULL`
- `5 = NULL` -> `NULL`
- The `case` falls through to `else 0`, so `row_count_delta` for the row is `0`

The configured `fail_calc` is `sum(coalesce(row_count_delta, 0))`, so the row again contributes `0` and the test silently passes.

### Concrete repro

Model A (our_model):

| group_col | rows |
|-----------|------|
| x         | 3    |
| y         | 5    |

Model B (compare_model):

| group_col | rows |
|-----------|------|
| x         | 3    |
| z         | 2    |

With `group_by_columns: ['group_col']` on either test, current `main` reports zero failures because the rows for `y` and `z` have `NULL` count on one side.

This matches the user-reported bug in #986 (false positive on Snowflake). The bug is in the ANSI SQL logic, not adapter-specific, so it affects every warehouse.

## Fix

Wrap the count fields in `coalesce(..., 0)` before subtraction and comparison, so a missing group is treated as a count of zero:

- `equal_rowcount.sql`:
  ```sql
  coalesce(count_a, 0) as count_a,
  coalesce(count_b, 0) as count_b,
  abs(coalesce(count_a, 0) - coalesce(count_b, 0)) as diff_count
  ```
- `fewer_rows_than.sql`: wrap both sides of each `>` and `=` comparison and the subtraction in the `then` branch.

The fix uses only ANSI SQL and does not introduce a new dialect-specific construct.

## Integration test

Adds two new seeds (`data_test_equal_rowcount_groups_a.csv`, `data_test_equal_rowcount_groups_b.csv`) and two new test models that wire up the regression scenario above:

- `test_equal_rowcount_groups` - runs `dbt_utils.equal_rowcount` with `group_by_columns: ['group_col']`. Uses `error_if: "<1"` so the test fails on `main` (because the macro reports zero failures despite the genuine mismatch) and passes post-fix (because the failure count is now `5 + 2 = 7`).
- `test_fewer_rows_than_groups` - same data, runs `dbt_utils.fewer_rows_than` with `group_by_columns: ['group_col']`. Same `error_if: "<1"` mechanism.

## Related

- Reported upstream: #986 (false positive in `equal_rowcount` with `group_by_columns` on Snowflake)
- This was discovered while maintaining a Fabric adapter override of these two macros that already applied the `coalesce(..., 0)` fix locally. The override is no longer necessary once this lands upstream.

## Checklist

- [x] CLA on file (signed for prior contributions)
- [x] No `CHANGELOG.md` edit (per `CONTRIBUTING.md`)
- [x] Adapter-agnostic - uses only ANSI SQL `coalesce`
- [x] Integration test covers the regression