### PR TITLE
ci: pin dbt-core install to 1.latest branch

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-dotenv
-dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
+dbt-core@git+https://github.com/dbt-labs/dbt-core.git@1.latest#subdirectory=core
 dbt-tests-adapter@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 dbt-postgres@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-postgres
 dbt-redshift@git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-redshift


### PR DESCRIPTION
## Summary
- Update [dev-requirements.txt](dev-requirements.txt) so the `dbt-core` git install pins to the `1.latest` branch instead of resolving to the repo's default branch (`main`).
- Migration from `main` → `1.latest` for the `dbt-core` reference only; `dbt-adapters`-sourced packages are intentionally left untouched in this PR.

## Test plan
- [ ] CI (Package Integration Tests) passes against Postgres, Redshift, Snowflake, BigQuery with `dbt-core` installed from the `1.latest` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)