### PR TITLE
feature/star-unquote-alias-rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,6 +1020,8 @@ This macro also has an optional `quote_identifiers` argument that will encase th
 - `prefix` (optional, default=`''`): will prefix the output `field_name` (`field_name as prefix_field_name`).
 - `suffix` (optional, default=`''`): will suffix the output `field_name` (`field_name as field_name_suffix`).
 - `quote_identifiers` (optional, default=`True`): will encase selected columns and aliases in double quotes (`"field_name" as "field_name"`).
+- `unquote_aliases` (optional, default=`False`): when `quote_identifiers=True`, renders aliases without quotes (`"field_name" as field_name`). Useful when reading from case-sensitive sources (e.g. Polaris/Iceberg catalogs) while producing unquoted aliases for downstream models that follow default case-folding rules.
+- `rename` (optional, default=`{}`): a dictionary mapping column names to custom alias names. The alias is always rendered unquoted. Takes precedence over `unquote_aliases` and `prefix`/`suffix` for the matched column. Useful for renaming reserved-word columns that cannot safely use an unquoted alias (e.g. `rename={"comment": "ticket_comment"}`).
 
 **Usage:**
 
@@ -1048,6 +1050,19 @@ from {{ ref('my_model') }}
 select
 {{ dbt_utils.star(from=ref('my_model'), except=["exclude_field_1", "exclude_field_2"], prefix="max_") }}
 from {{ ref('my_model') }}
+
+```
+
+```sql
+-- Produces: "id" as id, "description" as description, "comment" as ticket_comment
+select
+{{ dbt_utils.star(
+    from=source('my_source', 'my_table'),
+    quote_identifiers=true,
+    unquote_aliases=true,
+    rename={"comment": "ticket_comment"}
+) }}
+from {{ source('my_source', 'my_table') }}
 
 ```
 

--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -189,6 +189,12 @@ models:
       - dbt_utils.equality:
           compare_model: ref('data_star_expected')
 
+  - name: test_star_unquote_aliases
+    data_tests:
+      - assert_equal:
+          actual: actual
+          expected: expected
+
   - name: test_star_no_columns
     columns: 
       - name: canary_column #If the no-columns state isn't hit, this table won't be queryable because there will be a missing comma

--- a/integration_tests/models/sql/test_star_unquote_aliases.sql
+++ b/integration_tests/models/sql/test_star_unquote_aliases.sql
@@ -1,0 +1,18 @@
+{% set quoted_col = adapter.quote("column_one") %}
+
+
+select
+    {{ dbt.string_literal(quoted_col ~ " as column_one") | lower }} as expected,
+    {{ dbt.string_literal(dbt_utils.star(from=ref('data_star_quote_identifiers'), quote_identifiers=True, unquote_aliases=True)) | trim | lower }} as actual
+
+union all
+
+select
+    {{ dbt.string_literal(quoted_col ~ " as renamed_col") | lower }} as expected,
+    {{ dbt.string_literal(dbt_utils.star(from=ref('data_star_quote_identifiers'), quote_identifiers=True, unquote_aliases=True, rename={"column_one": "renamed_col"})) | trim | lower }} as actual
+
+union all
+
+select
+    {{ dbt.string_literal(quoted_col ~ " as renamed_col") | lower }} as expected,
+    {{ dbt.string_literal(dbt_utils.star(from=ref('data_star_quote_identifiers'), quote_identifiers=True, rename={"column_one": "renamed_col"})) | trim | lower }} as actual

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -1,8 +1,8 @@
-{% macro star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True) -%}
-    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix, quote_identifiers)) }}
+{% macro star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True, unquote_aliases=False, rename={}) -%}
+    {{ return(adapter.dispatch('star', 'dbt_utils')(from, relation_alias, except, prefix, suffix, quote_identifiers, unquote_aliases, rename)) }}
 {% endmacro %}
 
-{% macro default__star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True) -%}
+{% macro default__star(from, relation_alias=False, except=[], prefix='', suffix='', quote_identifiers=True, unquote_aliases=False, rename={}) -%}
     {%- do dbt_utils._is_relation(from, 'star') -%}
     {%- do dbt_utils._is_ephemeral(from, 'star') -%}
 
@@ -17,8 +17,8 @@
         {% if flags.WHICH == 'compile' %}
             {% set response %}
 *
-/* No columns were returned. Maybe the relation doesn't exist yet 
-or all columns were excluded. This star is only output during  
+/* No columns were returned. Maybe the relation doesn't exist yet
+or all columns were excluded. This star is only output during
 dbt compile, and exists to keep SQLFluff happy. */
             {% endset %}
             {% do return(response) %}
@@ -29,10 +29,17 @@ dbt compile, and exists to keep SQLFluff happy. */
         {%- for col in cols %}
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}
                 {%- if quote_identifiers -%}
-                    {{ adapter.quote(col)|trim }} {%- if prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }} {%- endif -%}
+                    {{ adapter.quote(col)|trim }}
+                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- elif unquote_aliases %} as {{ (prefix ~ col ~ suffix)|trim }}
+                    {%- elif prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }}
+                    {%- endif -%}
                 {%- else -%}
-                    {{ col|trim }} {%- if prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }} {%- endif -%}
-                {% endif %}
+                    {{ col|trim }}
+                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- elif prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }}
+                    {%- endif -%}
+                {%- endif -%}
             {%- if not loop.last %},{{ '\n  ' }}{%- endif -%}
         {%- endfor -%}
     {% endif %}


### PR DESCRIPTION
resolves #1093 

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

Particularly solves cases when using the `dbt_utils.star()` macro and want to retain case sensitivity in the identifier values (already covered by `quote_identifiers=True`) but don't want to retain case sensitivity for downstream queries. Particularly relevant for Snowflake when querying Polaris/Iceberg catalogs.

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

This PR introduces compatibility with the above desired functionality while not breaking the existing behavior for existing users. Users are able to leverage the new `unquote_aliases` parameter (default: False) to introduce aliases to the star macro results which are not quoted to ensure case insensitivity. 

Additionally, introduces a new parameter `rename` (default = `{}`) which allows users to specific certain fields known in the star query which could be reserved words in the database and rename them directly from the macro. This is particularly useful when wanting to retain case sensitivity in the identifier, but ensure the unquote_aliases don't fail with a reserved word failure.

See implementation examples below:
```sql
-- Model file
select
    {{ dbt_utils.star(source('zendesk','ticket_comment'), quote_identifiers=true, unquote_aliases=true, rename={'from':'from_user'}) }}
from {{ source('zendesk','ticket_comment') }}
```
Results
```sql
select
  "id" as id,
  "ticket_id" as ticket_id,
  "started_at" as started_at,
  "from" as from_user,
  etc...
from DATABASE."schema".ticket_comment
```

## Checklist
- [X] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have updated the README.md (if applicable)
