### PR TITLE
fix(star): match `rename` keys to column names case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ This macro also has an optional `quote_identifiers` argument that will encase th
 - `suffix` (optional, default=`''`): will suffix the output `field_name` (`field_name as field_name_suffix`).
 - `quote_identifiers` (optional, default=`True`): will encase selected columns and aliases in double quotes (`"field_name" as "field_name"`).
 - `unquote_aliases` (optional, default=`False`): when `quote_identifiers=True`, renders aliases without quotes (`"field_name" as field_name`). Useful when reading from case-sensitive sources (e.g. Polaris/Iceberg catalogs) while producing unquoted aliases for downstream models that follow default case-folding rules.
-- `rename` (optional, default=`{}`): a dictionary mapping column names to custom alias names. The alias is always rendered unquoted. Takes precedence over `unquote_aliases` and `prefix`/`suffix` for the matched column. Useful for renaming reserved-word columns that cannot safely use an unquoted alias (e.g. `rename={"comment": "ticket_comment"}`).
+- `rename` (optional, default=`{}`): a dictionary mapping column names to custom alias names. Keys are matched to column names case-insensitively (the same way `except` is), so a key works regardless of how the warehouse folds identifier case. The alias is always rendered unquoted. Takes precedence over `unquote_aliases` and `prefix`/`suffix` for the matched column. Useful for renaming reserved-word columns that cannot safely use an unquoted alias (e.g. `rename={"comment": "ticket_comment"}`).
 
 **Usage:**
 

--- a/integration_tests/models/sql/test_star_unquote_aliases.sql
+++ b/integration_tests/models/sql/test_star_unquote_aliases.sql
@@ -16,3 +16,12 @@ union all
 select
     {{ dbt.string_literal(quoted_col ~ " as renamed_col") | lower }} as expected,
     {{ dbt.string_literal(dbt_utils.star(from=ref('data_star_quote_identifiers'), quote_identifiers=True, rename={"column_one": "renamed_col"})) | trim | lower }} as actual
+
+union all
+
+-- `rename` keys should match column names case-insensitively, the same way `except` does.
+-- Warehouses that fold unquoted identifiers (e.g. Snowflake -> COLUMN_ONE) must still
+-- match a rename key supplied in a different case.
+select
+    {{ dbt.string_literal(quoted_col ~ " as renamed_col") | lower }} as expected,
+    {{ dbt.string_literal(dbt_utils.star(from=ref('data_star_quote_identifiers'), quote_identifiers=True, rename={"COLUMN_ONE": "renamed_col"})) | trim | lower }} as actual

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -13,6 +13,12 @@
 
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
+    {#-- Match `rename` keys to column names case-insensitively, consistent with how `except` is handled in get_filtered_columns_in_relation. This keeps the macro adapter-agnostic: warehouses such as Snowflake fold unquoted identifiers to a different case than the keys a user typically supplies. #}
+    {%- set rename_lookup = {} -%}
+    {%- for rename_key, rename_value in rename.items() -%}
+        {%- do rename_lookup.update({rename_key | lower: rename_value}) -%}
+    {%- endfor -%}
+
     {%- if cols|length <= 0 -%}
         {% if flags.WHICH == 'compile' %}
             {% set response %}
@@ -30,13 +36,13 @@ dbt compile, and exists to keep SQLFluff happy. */
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}
                 {%- if quote_identifiers -%}
                     {{ adapter.quote(col)|trim }}
-                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- if col | lower in rename_lookup %} as {{ rename_lookup[col | lower] }}
                     {%- elif unquote_aliases %} as {{ (prefix ~ col ~ suffix)|trim }}
                     {%- elif prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }}
                     {%- endif -%}
                 {%- else -%}
                     {{ col|trim }}
-                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- if col | lower in rename_lookup %} as {{ rename_lookup[col | lower] }}
                     {%- elif prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }}
                     {%- endif -%}
                 {%- endif -%}


### PR DESCRIPTION
resolves #1096

### Problem

The `rename` argument added to `star()` in #1094 matches rename keys to column names **case-sensitively** (`{% if col in rename %}`). On warehouses that fold unquoted identifiers to a fixed case — e.g. Snowflake stores `column_one` as `COLUMN_ONE` — `get_filtered_columns_in_relation()` returns the folded name, which never equals a lowercase key the user supplies (`{"column_one": ...}`). The rename is silently dropped and the column keeps its original name.

This is inconsistent with `except`, which `get_filtered_columns_in_relation` already normalizes case-insensitively (`except | map("lower")`). It also makes the new `test_star_unquote_aliases` integration test fail on Snowflake (`FAIL 2`), which is currently red on `main`.

### Solution

Build a lowercased `rename_lookup` once and match `col | lower` against it, mirroring how `except` is handled in `get_filtered_columns_in_relation`. This makes `rename` adapter-agnostic. Lowercase-folding adapters (Postgres / Redshift / BigQuery) are unaffected; Snowflake now applies renames correctly.

I also added a regression row to `test_star_unquote_aliases` that supplies a rename key in a **different case** than the stored column name (`COLUMN_ONE` vs `column_one`). This exercises the case-insensitive path on every adapter — not just Snowflake — so the bug is caught on the always-on Postgres job too.

### Before / after (verified locally on Postgres)

With rename key `{"COLUMN_ONE": "renamed_col"}` against a `column_one` column:

**Before** (case-sensitive lookup):
```
FAIL 1 — compiled to "column_one" with no alias
```

**After** (this PR):
```
PASS — compiled to "column_one" as renamed_col
```

Full `star` test suite on Postgres: `PASS=5`.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues/1096) (regression introduced in #1094).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] I have updated the README.md
