### PR TITLE
fix(recency): add fail_on_empty param to restore pre-1.4.0 CI behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* fix(recency): add `fail_on_empty` parameter (default `False`) to restore pre-1.4.0 behaviour for CI environments using `dbt --empty` by @onurtashan in https://github.com/dbt-labs/dbt-utils/pull/TBD
+
 **Full Changelog**: https://github.com/dbt-labs/dbt-utils/compare/1.4.0...main
 
 # dbt utils v1.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* fix(recency): add `fail_on_empty` parameter (default `False`) to restore pre-1.4.0 behaviour for CI environments using `dbt --empty` by @onurtashan in https://github.com/dbt-labs/dbt-utils/pull/TBD
+* fix(recency): add `fail_on_empty` parameter (default `False`) to restore pre-1.4.0 behaviour for CI environments using `dbt --empty` by @onurtashan in https://github.com/dbt-labs/dbt-utils/pull/1099
 
 **Full Changelog**: https://github.com/dbt-labs/dbt-utils/compare/1.4.0...main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# Unreleased
-
-* fix(recency): add `fail_on_empty` parameter (default `False`) to restore pre-1.4.0 behaviour for CI environments using `dbt --empty` by @onurtashan in https://github.com/dbt-labs/dbt-utils/pull/1099
-
-**Full Changelog**: https://github.com/dbt-labs/dbt-utils/compare/1.4.0...main
-
 # dbt utils v1.3.3
 
 * fix: Render relations to avoid including time filters in source_column_name by @harshvardhan-j in https://github.com/dbt-labs/dbt-utils/pull/1061

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+**Full Changelog**: https://github.com/dbt-labs/dbt-utils/compare/1.4.0...main
+
 # dbt utils v1.3.3
 
 * fix: Render relations to avoid including time filters in source_column_name by @harshvardhan-j in https://github.com/dbt-labs/dbt-utils/pull/1061

--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -1,8 +1,8 @@
-{% test recency(model, field, datepart, interval, ignore_time_component=False, group_by_columns = []) %}
-  {{ return(adapter.dispatch('test_recency', 'dbt_utils')(model, field, datepart, interval, ignore_time_component, group_by_columns)) }}
+{% test recency(model, field, datepart, interval, ignore_time_component=False, group_by_columns = [], fail_on_empty=False) %}
+  {{ return(adapter.dispatch('test_recency', 'dbt_utils')(model, field, datepart, interval, ignore_time_component, group_by_columns, fail_on_empty)) }}
 {% endtest %}
 
-{% macro default__test_recency(model, field, datepart, interval, ignore_time_component, group_by_columns) %}
+{% macro default__test_recency(model, field, datepart, interval, ignore_time_component, group_by_columns, fail_on_empty) %}
 
 {% set threshold = 'cast(' ~ dbt.dateadd(datepart, interval * -1, dbt.current_timestamp()) ~ ' as ' ~ ('date' if ignore_time_component else dbt.type_timestamp()) ~ ')'  %}
 
@@ -14,7 +14,7 @@
 
 with recency as (
 
-    select 
+    select
 
       {{ select_gb_cols }}
       {% if ignore_time_component %}
@@ -37,6 +37,8 @@ select
 
 from recency
 where most_recent < {{ threshold }}
+{% if fail_on_empty %}
    or most_recent is null
+{% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
## Summary

Adds a `fail_on_empty` parameter (default `False`) to the `recency` test, restoring the pre-1.4.0 behaviour for CI environments that use `dbt --empty`.

Fixes #1098

## Problem

1.4.0 introduced `or most_recent is null` to catch genuinely empty production tables. However, `dbt --empty` — dbt-core's official flag for CI slim builds — **intentionally** creates 0-row tables for schema and SQL validation. This causes every recency test to fail in CI, regardless of whether the test logic is correct.

The primary reason to run recency tests in CI with `--empty` is to **validate the test itself** (wrong column name → SQL error → CI catches it). 1.4.0 broke this workflow silently, without a breaking-change notice.

## Solution

```yaml
# CI: restore original pass-on-empty behaviour (default)
- dbt_utils.recency:
    arguments:
      datepart: hour
      field: sending_timestamp
      interval: 3

# Production: opt-in to catching empty tables
- dbt_utils.recency:
    arguments:
      datepart: hour
      field: sending_timestamp
      interval: 3
      fail_on_empty: true
```

## Behaviour

| Scenario | `fail_on_empty=False` (default) | `fail_on_empty=True` |
|---|---|---|
| Table has rows, data is fresh | ✅ PASS | ✅ PASS |
| Table has rows, data is stale | ❌ FAIL | ❌ FAIL |
| Table is empty (e.g. CI `--empty`) | ✅ PASS | ❌ FAIL |
| Wrong column name | ❌ SQL ERROR | ❌ SQL ERROR |

## Backwards compatibility

Default is `False` — restores pre-1.4.0 behaviour. Projects that relied on the 1.4.0 empty-table detection can opt in with `fail_on_empty: true`.
