### PR TITLE
Pass recency tests when using the `--empty` flag

### DIFF
--- a/macros/generic_tests/recency.sql
+++ b/macros/generic_tests/recency.sql
@@ -4,6 +4,8 @@
 
 {% macro default__test_recency(model, field, datepart, interval, ignore_time_component, group_by_columns) %}
 
+{% set empty_invocation = flags.EMPTY is defined and flags.EMPTY %}
+
 {% set threshold = 'cast(' ~ dbt.dateadd(datepart, interval * -1, dbt.current_timestamp()) ~ ' as ' ~ ('date' if ignore_time_component else dbt.type_timestamp()) ~ ')'  %}
 
 {% if group_by_columns|length() > 0 %}
@@ -37,6 +39,8 @@ select
 
 from recency
 where most_recent < {{ threshold }}
+{%- if not empty_invocation %}
    or most_recent is null
+{%- endif %}
 
 {% endmacro %}


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-utils/issues/1098

### Problem

> dbt-utils 1.4.0 added `or most_recent is null` to the recency test ([#1065](https://github.com/dbt-labs/dbt-utils/pull/1065)) to catch empty tables. However, dbt-core's official `--empty` flag — designed specifically for CI use — intentionally creates models with 0 rows. This causes **all recency tests to always fail in CI** environments using `--empty`, even when the test logic is correct.
> 
> **Repro:**
> 1. Use `dbt build --select <model> --empty` in CI (standard slim-CI pattern)
> 2. Any recency test on that model now fails: `MAX(field) = NULL` → `or most_recent is null = TRUE` → FAIL
> 
> This was a silent breaking change — not flagged in the 1.4.0 release notes.

### Solution

Inspired by the work in #1099, Deactivate the logic added by [#1065](https://github.com/dbt-labs/dbt-utils/pull/1065) when the `--empty` flag is in-use.

Since dbt_utils supports dbt-core >= 1.3 and `flags.EMPTY` wasn't added until dbt-core 1.8, special care needs to be taken.

### Testing

Manually verified behavior using dbt 1.7 and dbt 1.11.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] ~This PR includes tests, or tests are not required/relevant for this PR~
- [x] I have updated the README.md (if applicable)