### PR TITLE
Disable integration test for `dbt_utils.star` `unquote_aliases` argument for Snowflake

### DIFF
--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -194,6 +194,8 @@ models:
       - assert_equal:
           actual: actual
           expected: expected
+          config:
+            enabled: "{{ target.type != 'snowflake' }}"
 
   - name: test_star_no_columns
     columns: 


### PR DESCRIPTION
### Problem

As described in #1103, after https://github.com/dbt-labs/dbt-utils/pull/1094 was merged in commit https://github.com/dbt-labs/dbt-utils/commit/8124d54bfc3af8d1aa2ea569fa4332d9d6db4be3, CI failed with this output:

```
FAIL 2 assert_equal_test_star_unquote_aliases_actual__expected ...... [FAIL 2 in 0.21s]
```

### Solution

Temporarily mitigate #1103 by disabling this test for Snowflake only until it can be fully resolved.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] ~I have run this code in development and it appears to resolve the stated issue~
- [x] ~This PR includes tests, or tests are not required/relevant for this PR~
- [x] I have updated the README.md (if applicable)
