### PR TITLE
Temporarily disable automatic integration tests during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,13 @@
 
 name: Package Integration Tests
 
+# Automatic triggers temporarily disabled while investigating https://github.com/dbt-labs/dbt-utils/issues/1105
+# TODO: uncomment the push and pull_request_target triggers to re-enable integration tests once the root cause is fixed
 on:
-    push:
-        branches:
-            - main
-    pull_request_target:
+    # push:
+    #     branches:
+    #         - main
+    # pull_request_target:
     workflow_dispatch:
 
 


### PR DESCRIPTION
### Problem

As described in https://github.com/dbt-labs/dbt-utils/issues/1105, GitHub CI isn't a good indicator if the PR is good-to-go or not because it uses the code already merged to `main` rather than the code in the PR 😭

### Solution

Temporarily disable automatic integration tests during CI until we figure out how to resolve #1105

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] ~I have run this code in development and it appears to resolve the stated issue~
- [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
- [x] ~I have updated the README.md (if applicable)~
