### PR TITLE
fix/star-rename-casing

### DIFF
--- a/integration_tests/models/sql/schema.yml
+++ b/integration_tests/models/sql/schema.yml
@@ -194,8 +194,6 @@ models:
       - assert_equal:
           actual: actual
           expected: expected
-          config:
-            enabled: "{{ target.type != 'snowflake' }}"
 
   - name: test_star_no_columns
     columns: 

--- a/macros/sql/star.sql
+++ b/macros/sql/star.sql
@@ -13,6 +13,11 @@
 
     {% set cols = dbt_utils.get_filtered_columns_in_relation(from, except) %}
 
+    {%- set rename_lower = {} -%}
+    {%- for key, val in rename.items() -%}
+        {%- do rename_lower.update({key.lower(): val}) -%}
+    {%- endfor -%}
+
     {%- if cols|length <= 0 -%}
         {% if flags.WHICH == 'compile' %}
             {% set response %}
@@ -30,13 +35,13 @@ dbt compile, and exists to keep SQLFluff happy. */
             {%- if relation_alias %}{{ relation_alias }}.{% else %}{%- endif -%}
                 {%- if quote_identifiers -%}
                     {{ adapter.quote(col)|trim }}
-                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- if col.lower() in rename_lower %} as {{ rename_lower[col.lower()] }}
                     {%- elif unquote_aliases %} as {{ (prefix ~ col ~ suffix)|trim }}
                     {%- elif prefix!='' or suffix!='' %} as {{ adapter.quote(prefix ~ col ~ suffix)|trim }}
                     {%- endif -%}
                 {%- else -%}
                     {{ col|trim }}
-                    {%- if col in rename %} as {{ rename[col] }}
+                    {%- if col.lower() in rename_lower %} as {{ rename_lower[col.lower()] }}
                     {%- elif prefix!='' or suffix!='' %} as {{ (prefix ~ col ~ suffix)|trim }}
                     {%- endif -%}
                 {%- endif -%}
@@ -44,4 +49,3 @@ dbt compile, and exists to keep SQLFluff happy. */
         {%- endfor -%}
     {% endif %}
 {%- endmacro %}
-


### PR DESCRIPTION
resolves #1096
resolves #1103

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

PR #1094 introduced the `rename` parameter to `dbt_utils.star()`. This parameter does not work as expected for Snowflake due to the casing of default Snowflake fields. The previous implementation required the name of the field in `rename` to match the casing of the field in the table. As such, if the field was `"COLUMN_ONE"` then the rename parameter of `rename={'column_one':'renamed_col'}` wouldn't match. This is why the test was failing for Snowflake.

```sql
-- Using main branch
select
    {{ dbt_utils.star(source('zendesk','ticket_comment'), quote_identifiers=true, unquote_aliases=true, rename={'body':'content'}) }}
from {{ source('zendesk','ticket_comment') }}
```
results in 
```sql
select
  "CREATED" as CREATED,
  "PUBLIC" as PUBLIC,
  "BODY" as BODY, -- should be `"BODY" as content`
  "ID" as ID,
  "TICKET_ID" as TICKET_ID,
  "USER_ID" as USER_ID
from DATABASE.zendesk_schema.ticket_comment
```

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

This is addressed by ensuring the dictionary lookup of the key is lowered when in both the list and the check. This way it will be able to understand that `"COLUMN_ONE"` and `"column_one"` are the same and should be renamed accordingly.

A con of this approach is this could result in duplicative matches if there truly are two or more columns with the same name, but with different casing (eg. `"Column_One"`, `"COLUMN_ONE"`, `"column_one"`). If this is a hard blocker, the existing implementation is sufficient. However, the test will need to be modified for Snowflake to ensure the key in rename is all caps and the documentation will need to be updated. My reasoning for taking the approach in this PR is this is similar to how `except` works currently. Since there's precedent it felt appropriate to take this approach.

```sql
-- Using this PR branch
select
    {{ dbt_utils.star(source('zendesk','ticket_comment'), quote_identifiers=true, unquote_aliases=true, rename={'body':'content'}) }}
from {{ source('zendesk','ticket_comment') }}
```
results in

```sql
select
  "CREATED" as CREATED,
  "PUBLIC" as PUBLIC,
  "BODY" as content, -- is now correct
  "ID" as ID,
  "TICKET_ID" as TICKET_ID,
  "USER_ID" as USER_ID
from DATABASE.zendesk_schema.ticket_comment
```

## Checklist
- [X] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues) which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests).
- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the README.md (if applicable)
