### PR TITLE
fix: use run_query in get_column_values to avoid statement name collision

### DIFF
--- a/macros/sql/get_column_values.sql
+++ b/macros/sql/get_column_values.sql
@@ -18,24 +18,20 @@
     {# adapter.load_relation is a convenience wrapper to avoid building a Relation when we already have one #}
     {% set relation_exists = (load_relation(target_relation)) is not none %}
 
-    {%- call statement('get_column_values', fetch_result=true) %}
+    {%- if not relation_exists and default is none -%}
 
-        {%- if not relation_exists and default is none -%}
+        {{ exceptions.raise_compiler_error("In get_column_values(): relation " ~ target_relation ~ " does not exist and no default value was provided.") }}
 
-          {{ exceptions.raise_compiler_error("In get_column_values(): relation " ~ target_relation ~ " does not exist and no default value was provided.") }}
+    {%- elif not relation_exists and default is not none -%}
 
-        {%- elif not relation_exists and default is not none -%}
+        {{ log("Relation " ~ target_relation ~ " does not exist. Returning the default value: " ~ default) }}
+        {{ return(default) }}
 
-          {{ log("Relation " ~ target_relation ~ " does not exist. Returning the default value: " ~ default) }}
+    {%- else -%}
 
-          {{ return(default) }}
-
-        {%- else -%}
-
-
+        {%- set query -%}
             select
                 {{ column }} as value
-
             from {{ target_relation }}
 
             {% if where is not none %}
@@ -48,18 +44,17 @@
             {% if max_records is not none %}
             limit {{ max_records }}
             {% endif %}
+        {%- endset -%}
 
-        {% endif %}
+        {%- set value_list = run_query(query) -%}
 
-    {%- endcall -%}
+        {%- if value_list and value_list.rows -%}
+            {%- set values = value_list.columns[0].values() | list -%}
+            {{ return(values) }}
+        {%- else -%}
+            {{ return(default) }}
+        {%- endif -%}
 
-    {%- set value_list = load_result('get_column_values') -%}
-
-    {%- if value_list and value_list['data'] -%}
-        {%- set values = value_list['data'] | map(attribute=0) | list %}
-        {{ return(values) }}
-    {%- else -%}
-        {{ return(default) }}
     {%- endif -%}
 
 {%- endmacro %}


### PR DESCRIPTION
Fixes #1079

The macro uses a hardcoded name in statement('get_column_values') which gets stored in the global context. When two models call this macro in the same dbt run, the second call hits MacroResultAlreadyLoadedError because the name is already registered.

Switched to un_query() which returns results directly without touching global state. Also updated result access to match the agate.Table API.

Tested locally with dbt-duckdb by calling the macro twice in one model - no error after the fix.