### PR TITLE
fix(get_single_value): route 'no rows' message through log()

### DIFF
--- a/macros/sql/get_single_value.sql
+++ b/macros/sql/get_single_value.sql
@@ -16,7 +16,7 @@
 
         {% set r = load_result('get_query_result').table.columns[0].values() %}
         {% if r | length == 0 %}
-            {% do print('Query `' ~ query ~ '` returned no rows. Using the default value: ' ~ default) %}
+            {{ log("Query `" ~ query ~ "` returned no rows. Using the default value: " ~ default) }}
             {% set sql_result = default %}
         {% else %}
             {% set sql_result = r[0] %}


### PR DESCRIPTION
resolves #1049

### Problem

`get_single_value` uses `print()` to surface its 'no rows returned, using default' message. This writes directly to stdout, so it can't be filtered by dbt's log-level flags and shows up alongside real errors in noisy CI output. The related macro `get_column_values` already routes its equivalent message through `log()` (see [get_column_values.sql:29](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/get_column_values.sql#L29)) — this brings `get_single_value` into line with that pattern.

### Solution

Replace `{% do print(...) %}` with `{{ log(...) }}`. One-line change, matches the existing style used elsewhere in `macros/sql/`.

The message text is unchanged, so downstream users grepping logs continue to work. Existing integration tests in `integration_tests/models/sql/test_get_single_value.sql` cover the default-value path and continue to pass.

## Checklist
- [x] This code is associated with an [issue](https://github.com/dbt-labs/dbt-utils/issues/1049) which has been triaged
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-utils/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR (existing tests cover the code path)
- [x] I have updated the README.md (if applicable) — n/a, no docs change